### PR TITLE
Default values on controller methods are now honored

### DIFF
--- a/src/ControllerQueryProvider.php
+++ b/src/ControllerQueryProvider.php
@@ -7,7 +7,7 @@ use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Boolean;
 use phpDocumentor\Reflection\Types\Float_;
-use phpDocumentor\Reflection\Types\Mixed;
+use phpDocumentor\Reflection\Types\Mixed_;
 use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\String_;
 use Roave\BetterReflection\Reflection\ReflectionClass;
@@ -200,7 +200,7 @@ class ControllerQueryProvider implements QueryProviderInterface
     {
         $graphQlType = null;
 
-        if ($type instanceof Array_ || $type instanceof Mixed) {
+        if ($type instanceof Array_ || $type instanceof Mixed_) {
             if (!$isNullable) {
                 // Let's check a "null" value in the docblock
                 $isNullable = $this->isNullable($docBlockTypes);

--- a/src/ControllerQueryProvider.php
+++ b/src/ControllerQueryProvider.php
@@ -156,6 +156,7 @@ class ControllerQueryProvider implements QueryProviderInterface
      * @param ReflectionMethod $refMethod
      * @param \ReflectionMethod $standardRefMethod
      * @return array
+     * @throws MissingTypeHintException
      */
     private function mapParameters(ReflectionMethod $refMethod, \ReflectionMethod $standardRefMethod)
     {
@@ -167,9 +168,24 @@ class ControllerQueryProvider implements QueryProviderInterface
             $allowsNull = $standardParameter->allowsNull();
             $parameter = $refMethod->getParameter($standardParameter->getName());
 
-            $phpdocType = $typeResolver->resolve((string) $parameter->getType());
+            $type = (string) $parameter->getType();
+            if ($type === '') {
+                throw MissingTypeHintException::missingTypeHint($parameter);
+            }
+            $phpdocType = $typeResolver->resolve($type);
 
-            $args[$parameter->getName()] = $this->mapType($phpdocType, $parameter->getDocBlockTypes(), $allowsNull, true);
+            $arr = [
+                'type' => $this->mapType($phpdocType, $parameter->getDocBlockTypes(), $allowsNull, true),
+            ];
+
+            if ($standardParameter->allowsNull()) {
+                $arr['default'] = null;
+            }
+            if ($standardParameter->isDefaultValueAvailable()) {
+                $arr['default'] = $standardParameter->getDefaultValue();
+            }
+
+            $args[$parameter->getName()] = $arr;
         }
 
         return $args;

--- a/src/MissingTypeHintException.php
+++ b/src/MissingTypeHintException.php
@@ -1,0 +1,12 @@
+<?php
+namespace TheCodingMachine\GraphQL\Controllers;
+
+use Roave\BetterReflection\Reflection\ReflectionParameter;
+
+class MissingTypeHintException extends GraphQLException
+{
+    public static function missingTypeHint(ReflectionParameter $parameter)
+    {
+        return new self(sprintf('Parameter "%s" of method "%s::%s" is missing a type-hint', $parameter->getName(), $parameter->getDeclaringClass()->getName(), $parameter->getDeclaringFunction()->getName()));
+    }
+}

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -35,30 +35,36 @@ class QueryField extends AbstractField
         $config = [
             'name' => $name,
             'type' => $type,
-            'args' => $arguments
+            'args' => array_map(function(array $item) { return $item['type']; }, $arguments)
         ];
 
         $config['resolve'] = function ($source, array $args, ResolveInfo $info) use ($resolve, $arguments) {
             $toPassArgs = [];
-            foreach ($arguments as $name => $type) {
-                // FIXME: this is not ok for default values! We need to take the default value of the reflected argument.
-                $val = $args[$name] ?? null;
+            foreach ($arguments as $name => $arr) {
+                $type = $arr['type'];
+                if (isset($args[$name])) {
+                    $val = $args[$name];
 
-                $type = $this->stripNonNullType($type);
-                if ($type instanceof ListType) {
-                    $subtype = $this->stripNonNullType($type->getItemType());
-                    $val = array_map(function ($item) use ($subtype) {
-                        if ($subtype instanceof DateTimeType) {
-                            return new \DateTimeImmutable($item);
-                        } elseif ($subtype->getKind() === TypeMap::KIND_INPUT_OBJECT) {
-                            return $this->hydrator->hydrate($item, $subtype);
-                        };
-                        return $item;
-                    }, $val);
-                } elseif ($type instanceof DateTimeType) {
-                    $val = new \DateTimeImmutable($val);
-                } elseif ($type->getKind() === TypeMap::KIND_INPUT_OBJECT) {
-                    $val = $this->hydrator->hydrate($val, $type);
+                    $type = $this->stripNonNullType($type);
+                    if ($type instanceof ListType) {
+                        $subtype = $this->stripNonNullType($type->getItemType());
+                        $val = array_map(function ($item) use ($subtype) {
+                            if ($subtype instanceof DateTimeType) {
+                                return new \DateTimeImmutable($item);
+                            } elseif ($subtype->getKind() === TypeMap::KIND_INPUT_OBJECT) {
+                                return $this->hydrator->hydrate($item, $subtype);
+                            };
+                            return $item;
+                        }, $val);
+                    } elseif ($type instanceof DateTimeType) {
+                        $val = new \DateTimeImmutable($val);
+                    } elseif ($type->getKind() === TypeMap::KIND_INPUT_OBJECT) {
+                        $val = $this->hydrator->hydrate($val, $type);
+                    }
+                } elseif (isset($arr['default'])) {
+                    $val = $arr['default'];
+                } else {
+                    throw new GraphQLException("Expected argument '$name' was not provided.");
                 }
 
                 $toPassArgs[] = $val;

--- a/tests/ControllerQueryProviderTest.php
+++ b/tests/ControllerQueryProviderTest.php
@@ -19,6 +19,7 @@ use Youshido\GraphQL\Type\Scalar\FloatType;
 use Youshido\GraphQL\Type\Scalar\IntType;
 use Youshido\GraphQL\Type\Scalar\StringType;
 use Youshido\GraphQL\Type\TypeInterface;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Query;
 
 class ControllerQueryProviderTest extends AbstractQueryProviderTest
 {
@@ -35,7 +36,7 @@ class ControllerQueryProviderTest extends AbstractQueryProviderTest
         $usersQuery = $queries[0];
         $this->assertSame('test', $usersQuery->getName());
 
-        $this->assertCount(7, $usersQuery->getArguments());
+        $this->assertCount(8, $usersQuery->getArguments());
         $this->assertInstanceOf(NonNullType::class, $usersQuery->getArgument('int')->getType());
         $this->assertInstanceOf(IntType::class, $usersQuery->getArgument('int')->getType()->getTypeOf());
         $this->assertInstanceOf(StringType::class, $usersQuery->getArgument('string')->getType());
@@ -62,7 +63,7 @@ class ControllerQueryProviderTest extends AbstractQueryProviderTest
         ], $mockResolveInfo);
 
         $this->assertInstanceOf(TestObject::class, $result);
-        $this->assertSame('foo424212true4.22017010101010120170101010101', $result->getTest());
+        $this->assertSame('foo424212true4.22017010101010120170101010101default', $result->getTest());
     }
 
     public function testMutations()
@@ -84,5 +85,25 @@ class ControllerQueryProviderTest extends AbstractQueryProviderTest
 
         $this->assertInstanceOf(TestObject::class, $result);
         $this->assertEquals('42', $result->getTest());
+    }
+
+    public function testErrors()
+    {
+        $controller = new class {
+            /**
+             * @Query
+             * @return string
+             */
+            public function test($noTypeHint): string
+            {
+                return 'foo';
+            }
+        };
+        $reader = new AnnotationReader();
+
+        $queryProvider = new ControllerQueryProvider($controller, $reader, $this->getTypeMapper(), $this->getHydrator(), new VoidAuthenticationService(), new VoidAuthorizationService());
+
+        $this->expectException(MissingTypeHintException::class);
+        $queryProvider->getQueries();
     }
 }

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -21,7 +21,7 @@ class TestController
      * @param \DateTime|null $dateTime
      * @return TestObject
      */
-    public function test(int $int, ?string $string, array $list, ?bool $boolean, ?float $float, ?\DateTimeImmutable $dateTimeImmutable, ?\DateTimeInterface $dateTime): TestObject
+    public function test(int $int, ?string $string, array $list, ?bool $boolean, ?float $float, ?\DateTimeImmutable $dateTimeImmutable, ?\DateTimeInterface $dateTime, string $withDefault = 'default'): TestObject
     {
         $str = '';
         foreach ($list as $test) {
@@ -30,7 +30,7 @@ class TestController
             }
             $str .= $test->getTest();
         }
-        return new TestObject($string.$int.$str.($boolean?'true':'false').$float.$dateTimeImmutable->format('YmdHis').$dateTime->format('YmdHis'));
+        return new TestObject($string.$int.$str.($boolean?'true':'false').$float.$dateTimeImmutable->format('YmdHis').$dateTime->format('YmdHis').$withDefault);
     }
 
     /**


### PR DESCRIPTION
Previously, default values were ignored and null was inputed.
This PR fixes this issue.