### PR TITLE
Adding a field annotation

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,7 +2,11 @@ build:
     environment:
         php:
             version: 7.1
-
+    nodes:
+        analysis:
+            tests:
+                override:
+                    - php-scrutinizer-run
 checks:
     php:
         code_rating: true

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ $queryProvider = new AggregateControllerQueryProvider([
     ],
     $container, // The container containing the controllers (PSR-11 compliant),
     $annotationReader, // A Doctrine annotation reader
-    $typeMapper, // Object used to map PHP classes to GraphQL types. 
+    $typeMapper, // Object used to map PHP classes to GraphQL types.
     $hydrator, // Object used to create Objects from sent data (mostly for mutation)
     $authenticationService, // Object to manage authentication (the @Logged annotation)
     AuthorizationServiceInterface $authorizationService // Object to manage authorization (the @Right annotation)

--- a/README.md
+++ b/README.md
@@ -144,21 +144,77 @@ Controllers will be fetched from the container (it must be PSR-11 compliant).
 Pseudo-code to initialize the middleware looks like this:
 
 ```php
+$registry = new Registry(
+  $container, // The container containing the controllers (PSR-11 compliant),
+  $authorizationService // Object to manage authorization (the @Right annotation)  
+  $authenticationService, // Object to manage authentication (the @Logged annotation)
+  $annotationReader, // A Doctrine annotation reader
+  $typeMapper, // Object used to map PHP classes to GraphQL types.
+  $hydrator, // Object used to create Objects from sent data (mostly for mutation)
+);
+
 $queryProvider = new AggregateControllerQueryProvider([
         "myController1", // These are the name of entries in the container to fetch the GraphQL controllers
         "myController2"
     ],
-    $container, // The container containing the controllers (PSR-11 compliant),
-    $annotationReader, // A Doctrine annotation reader
-    $typeMapper, // Object used to map PHP classes to GraphQL types.
-    $hydrator, // Object used to create Objects from sent data (mostly for mutation)
-    $authenticationService, // Object to manage authentication (the @Logged annotation)
-    AuthorizationServiceInterface $authorizationService // Object to manage authorization (the @Right annotation)
-    )
-);
-```  
+    $registry
+  );
+```
 
+Using @Field annotation in object types
+=======================================
 
+When you use youshido/graphql, you will typically extend the `AbstractObjectType` class to declare your GraphQL types.
+
+Typical code looks like this:
+
+```php
+class PostType extends AbstractObjectType
+{
+
+    public function build($config)
+    {
+        // you can define fields in a single addFields call instead of chaining multiple addField()
+        $config->addFields([
+            'title'      => [
+                'type' => new StringType(),
+                'args'              => [
+                    'truncate' => new BooleanType()
+                ],
+                'resolve'           => function (Post $source, $args) {
+                    return (!empty($args['truncate'])) ? explode(' ', $source->getTitle())[0] . '...' : $source->getTitle();
+                }
+            ]
+        ]);
+    }
+}
+```
+
+You can replace the whole `build` method with methods with the @Field annotation:
+
+```php
+class PostType extends AbstractAnnotatedObjectType
+{
+    /**
+     * @Field()
+     */
+    public function customField(Post $source, bool $truncate = false): string
+    {
+        return (!empty($args['truncate'])) ? explode(' ', $source->getTitle())[0] . '...' : $source->getTitle();
+    }
+}
+```
+
+You simply have to:
+
+- extend the `AbstractAnnotatedObjectType` class
+- add the @Field annotation
+- when constructing the object, you must pass the $registry object as the first argument:
+  ```php
+  $postType = new PostType($registry);
+  ```
+
+Please note that the first argument of the method is the object we are calling the field on. The remaining arguments are converted to GraphQL arguments of the field.
 
 Troubleshooting
 ---------------

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     },
     "minimum-stability": "dev",

--- a/src/AbstractAnnotatedObjectType.php
+++ b/src/AbstractAnnotatedObjectType.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+
+use TheCodingMachine\GraphQL\Controllers\Registry\RegistryInterface;
+use Youshido\GraphQL\Type\Object\AbstractObjectType;
+
+abstract class AbstractAnnotatedObjectType extends AbstractObjectType
+{
+    /**
+     * @var RegistryInterface
+     */
+    private $registry;
+
+    public function __construct(RegistryInterface $registry)
+    {
+        $this->registry = $registry;
+        parent::__construct([]);
+    }
+
+    /**
+     * @param ObjectTypeConfig $config
+     */
+    public function build($config)
+    {
+        $fieldProvider = new ControllerQueryProvider($this, $this->registry);
+        $fields = $fieldProvider->getFields();
+        $this->addFields($fields);
+    }
+}

--- a/src/AbstractAnnotatedObjectType.php
+++ b/src/AbstractAnnotatedObjectType.php
@@ -5,6 +5,7 @@ namespace TheCodingMachine\GraphQL\Controllers;
 
 
 use TheCodingMachine\GraphQL\Controllers\Registry\RegistryInterface;
+use Youshido\GraphQL\Config\Object\ObjectTypeConfig;
 use Youshido\GraphQL\Type\Object\AbstractObjectType;
 
 abstract class AbstractAnnotatedObjectType extends AbstractObjectType

--- a/src/Annotations/Field.php
+++ b/src/Annotations/Field.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Annotations;
+
+/**
+ * @Annotation
+ * @Attributes({
+ *   @Attribute("returnType", type = "string"),
+ * })
+ */
+class Field extends AbstractRequest
+{
+}

--- a/src/ControllerQueryProvider.php
+++ b/src/ControllerQueryProvider.php
@@ -8,6 +8,7 @@ use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Boolean;
 use phpDocumentor\Reflection\Types\Float_;
 use phpDocumentor\Reflection\Types\Mixed_;
+use phpDocumentor\Reflection\Types\Null_;
 use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\String_;
 use Psr\Container\ContainerInterface;
@@ -85,7 +86,7 @@ class ControllerQueryProvider implements QueryProviderInterface
     }
 
     /**
-     * @return Field[]
+     * @return QueryField[]
      */
     public function getQueries(): array
     {
@@ -93,7 +94,7 @@ class ControllerQueryProvider implements QueryProviderInterface
     }
 
     /**
-     * @return Field[]
+     * @return QueryField[]
      */
     public function getMutations(): array
     {
@@ -101,7 +102,7 @@ class ControllerQueryProvider implements QueryProviderInterface
     }
 
     /**
-     * @return Field[]
+     * @return QueryField[]
      */
     public function getFields(): array
     {
@@ -111,7 +112,7 @@ class ControllerQueryProvider implements QueryProviderInterface
     /**
      * @param string $annotationName
      * @param bool $injectSource Whether to inject the source object or not as the first argument. True for @Field, false for @Query and @Mutation
-     * @return Field[]
+     * @return QueryField[]
      * @throws \ReflectionException
      */
     private function getFieldsByAnnotations(string $annotationName, bool $injectSource): array

--- a/src/ControllerQueryProvider.php
+++ b/src/ControllerQueryProvider.php
@@ -23,6 +23,7 @@ use TheCodingMachine\GraphQL\Controllers\Annotations\Right;
 use TheCodingMachine\GraphQL\Controllers\Reflection\CommentParser;
 use TheCodingMachine\GraphQL\Controllers\Registry\EmptyContainer;
 use TheCodingMachine\GraphQL\Controllers\Registry\Registry;
+use TheCodingMachine\GraphQL\Controllers\Registry\RegistryInterface;
 use TheCodingMachine\GraphQL\Controllers\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQL\Controllers\Security\AuthorizationServiceInterface;
 use Youshido\GraphQL\Field\Field;
@@ -65,22 +66,22 @@ class ControllerQueryProvider implements QueryProviderInterface
      */
     private $authorizationService;
     /**
-     * @var ContainerInterface
+     * @var RegistryInterface
      */
     private $registry;
 
     /**
      * @param object $controller
      */
-    public function __construct($controller, Reader $annotationReader, TypeMapperInterface $typeMapper, HydratorInterface $hydrator, AuthenticationServiceInterface $authenticationService, AuthorizationServiceInterface $authorizationService, ?ContainerInterface $container = null)
+    public function __construct($controller, RegistryInterface $registry)
     {
         $this->controller = $controller;
-        $this->annotationReader = $annotationReader;
-        $this->typeMapper = $typeMapper;
-        $this->hydrator = $hydrator;
-        $this->authenticationService = $authenticationService;
-        $this->authorizationService = $authorizationService;
-        $this->registry = new Registry($container ?: new EmptyContainer());
+        $this->annotationReader = $registry->getAnnotationReader();
+        $this->typeMapper = $registry->getTypeMapper();
+        $this->hydrator = $registry->getHydrator();
+        $this->authenticationService = $registry->getAuthenticationService();
+        $this->authorizationService = $registry->getAuthorizationService();
+        $this->registry = $registry;
     }
 
     /**
@@ -88,7 +89,7 @@ class ControllerQueryProvider implements QueryProviderInterface
      */
     public function getQueries(): array
     {
-        return $this->getFieldsByAnnotations(Query::class);
+        return $this->getFieldsByAnnotations(Query::class, false);
     }
 
     /**
@@ -96,13 +97,24 @@ class ControllerQueryProvider implements QueryProviderInterface
      */
     public function getMutations(): array
     {
-        return $this->getFieldsByAnnotations(Mutation::class);
+        return $this->getFieldsByAnnotations(Mutation::class, false);
     }
 
     /**
      * @return Field[]
      */
-    private function getFieldsByAnnotations(string $annotationName): array
+    public function getFields(): array
+    {
+        return $this->getFieldsByAnnotations(Annotations\Field::class, true);
+    }
+
+    /**
+     * @param string $annotationName
+     * @param bool $injectSource Whether to inject the source object or not as the first argument. True for @Field, false for @Query and @Mutation
+     * @return Field[]
+     * @throws \ReflectionException
+     */
+    private function getFieldsByAnnotations(string $annotationName, bool $injectSource): array
     {
         $refClass = ReflectionClass::createFromInstance($this->controller);
 
@@ -112,7 +124,7 @@ class ControllerQueryProvider implements QueryProviderInterface
 
         foreach ($refClass->getMethods() as $refMethod) {
             $standardPhpMethod = new \ReflectionMethod(get_class($this->controller), $refMethod->getName());
-            // First, let's check the "Query" annotation
+            // First, let's check the "Query" or "Mutation" or "Field" annotation
             $queryAnnotation = $this->annotationReader->getMethodAnnotation($standardPhpMethod, $annotationName);
             /* @var $queryAnnotation AbstractRequest */
 
@@ -138,7 +150,15 @@ class ControllerQueryProvider implements QueryProviderInterface
                     }
                 }
 
-                $queryList[] = new QueryField($methodName, $type, $args, [$this->controller, $methodName], $this->hydrator, $docBlock->getComment());
+                //$sourceType = null;
+                if ($injectSource === true) {
+                    /*$sourceArr = */\array_shift($args);
+                    // Security check: if the first parameter of the correct type?
+                    //$sourceType = $sourceArr['type'];
+                    /* @var $sourceType TypeInterface */
+                    // TODO
+                }
+                $queryList[] = new QueryField($methodName, $type, $args, [$this->controller, $methodName], $this->hydrator, $docBlock->getComment(), $injectSource);
             }
         }
 
@@ -174,10 +194,10 @@ class ControllerQueryProvider implements QueryProviderInterface
      *
      * @param ReflectionMethod $refMethod
      * @param \ReflectionMethod $standardRefMethod
-     * @return array
+     * @return array[] An array of ['type'=>TypeInterface, 'default'=>val]
      * @throws MissingTypeHintException
      */
-    private function mapParameters(ReflectionMethod $refMethod, \ReflectionMethod $standardRefMethod)
+    private function mapParameters(ReflectionMethod $refMethod, \ReflectionMethod $standardRefMethod): array
     {
         $args = [];
 

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -14,6 +14,9 @@ use Youshido\GraphQL\Type\Scalar\DateTimeType;
 use Youshido\GraphQL\Type\TypeInterface;
 use Youshido\GraphQL\Type\TypeMap;
 
+/**
+ * A GraphQL field that maps to a PHP method automatically.
+ */
 class QueryField extends AbstractField
 {
     /**
@@ -27,9 +30,12 @@ class QueryField extends AbstractField
      * @param TypeInterface $type
      * @param TypeInterface[] $arguments Indexed by argument name.
      * @param callable $resolve
+     * @param HydratorInterface $hydrator
+     * @param null|string $comment
+     * @param bool $injectSource Whether to inject the source object (for Fields), or null for Query and Mutations
      * @param array $additionalConfig
      */
-    public function __construct(string $name, TypeInterface $type, array $arguments, callable $resolve, HydratorInterface $hydrator, ?string $comment, array $additionalConfig = [])
+    public function __construct(string $name, TypeInterface $type, array $arguments, callable $resolve, HydratorInterface $hydrator, ?string $comment, bool $injectSource, array $additionalConfig = [])
     {
         $this->hydrator = $hydrator;
         $config = [
@@ -41,8 +47,11 @@ class QueryField extends AbstractField
             $config['description'] = $comment;
         }
 
-        $config['resolve'] = function ($source, array $args, ResolveInfo $info) use ($resolve, $arguments) {
+        $config['resolve'] = function ($source, array $args, ResolveInfo $info) use ($resolve, $arguments, $injectSource) {
             $toPassArgs = [];
+            if ($injectSource) {
+                $toPassArgs[] = $source;
+            }
             foreach ($arguments as $name => $arr) {
                 $type = $arr['type'];
                 if (isset($args[$name])) {

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -28,7 +28,7 @@ class QueryField extends AbstractField
      * QueryField constructor.
      * @param string $name
      * @param TypeInterface $type
-     * @param TypeInterface[] $arguments Indexed by argument name.
+     * @param array[] $arguments Indexed by argument name, value: ['type'=>TypeInterface, 'default'=>val].
      * @param callable $resolve
      * @param HydratorInterface $hydrator
      * @param null|string $comment

--- a/src/Registry/Registry.php
+++ b/src/Registry/Registry.php
@@ -3,17 +3,21 @@
 
 namespace TheCodingMachine\GraphQL\Controllers\Registry;
 
+use Doctrine\Common\Annotations\Reader;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use TheCodingMachine\GraphQL\Controllers\HydratorInterface;
+use TheCodingMachine\GraphQL\Controllers\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQL\Controllers\Security\AuthorizationServiceInterface;
+use TheCodingMachine\GraphQL\Controllers\TypeMapperInterface;
 use Youshido\GraphQL\Type\Object\AbstractObjectType;
 
 /**
  * The role of the registry is to provide access to all GraphQL types.
  * If the type is not found, it can be queried from the container, or if not in the container, it can be created from the Registry itself.
  */
-class Registry implements ContainerInterface
+class Registry implements RegistryInterface
 {
 
     /**
@@ -29,15 +33,34 @@ class Registry implements ContainerInterface
      * @var null|AuthorizationServiceInterface
      */
     private $authorizationService;
+    /**
+     * @var AuthenticationServiceInterface
+     */
+    private $authenticationService;
+    /**
+     * @var Reader
+     */
+    private $annotationReader;
+    /**
+     * @var TypeMapperInterface
+     */
+    private $typeMapper;
+    /**
+     * @var HydratorInterface
+     */
+    private $hydrator;
 
     /**
      * @param ContainerInterface $container The proxied container.
-     * @param AuthorizationServiceInterface|null $authorizationService
      */
-    public function __construct(ContainerInterface $container, AuthorizationServiceInterface $authorizationService = null)
+    public function __construct(ContainerInterface $container, AuthorizationServiceInterface $authorizationService, AuthenticationServiceInterface $authenticationService, Reader $annotationReader, TypeMapperInterface $typeMapper, HydratorInterface $hydrator)
     {
         $this->container = $container;
         $this->authorizationService = $authorizationService;
+        $this->authenticationService = $authenticationService;
+        $this->annotationReader = $annotationReader;
+        $this->typeMapper = $typeMapper;
+        $this->hydrator = $hydrator;
     }
 
     /**
@@ -97,10 +120,42 @@ class Registry implements ContainerInterface
     /**
      * Returns the authorization service.
      *
-     * @return AuthorizationServiceInterface|null
+     * @return AuthorizationServiceInterface
      */
-    public function getAuthorizationService(): ?AuthorizationServiceInterface
+    public function getAuthorizationService(): AuthorizationServiceInterface
     {
         return $this->authorizationService;
+    }
+
+    /**
+     * @return AuthenticationServiceInterface
+     */
+    public function getAuthenticationService(): AuthenticationServiceInterface
+    {
+        return $this->authenticationService;
+    }
+
+    /**
+     * @return Reader
+     */
+    public function getAnnotationReader(): Reader
+    {
+        return $this->annotationReader;
+    }
+
+    /**
+     * @return TypeMapperInterface
+     */
+    public function getTypeMapper(): TypeMapperInterface
+    {
+        return $this->typeMapper;
+    }
+
+    /**
+     * @return HydratorInterface
+     */
+    public function getHydrator(): HydratorInterface
+    {
+        return $this->hydrator;
     }
 }

--- a/src/Registry/RegistryInterface.php
+++ b/src/Registry/RegistryInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers\Registry;
+
+use Doctrine\Common\Annotations\Reader;
+use Psr\Container\ContainerInterface;
+use TheCodingMachine\GraphQL\Controllers\HydratorInterface;
+use TheCodingMachine\GraphQL\Controllers\Security\AuthenticationServiceInterface;
+use TheCodingMachine\GraphQL\Controllers\Security\AuthorizationServiceInterface;
+use TheCodingMachine\GraphQL\Controllers\TypeMapperInterface;
+
+
+/**
+ * The role of the registry is to provide access to all GraphQL types.
+ * If the type is not found, it can be queried from the container, or if not in the container, it can be created from the Registry itself.
+ */
+interface RegistryInterface extends ContainerInterface
+{
+    /**
+     * Returns the authorization service.
+     *
+     * @return AuthorizationServiceInterface
+     */
+    public function getAuthorizationService(): AuthorizationServiceInterface;
+
+    /**
+     * @return AuthenticationServiceInterface
+     */
+    public function getAuthenticationService(): AuthenticationServiceInterface;
+
+    /**
+     * @return Reader
+     */
+    public function getAnnotationReader(): Reader;
+
+    /**
+     * @return TypeMapperInterface
+     */
+    public function getTypeMapper(): TypeMapperInterface;
+
+    /**
+     * @return HydratorInterface
+     */
+    public function getHydrator(): HydratorInterface;
+}

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -3,8 +3,14 @@
 
 namespace TheCodingMachine\GraphQL\Controllers;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\TestObject;
+use TheCodingMachine\GraphQL\Controllers\Registry\EmptyContainer;
+use TheCodingMachine\GraphQL\Controllers\Registry\Registry;
+use TheCodingMachine\GraphQL\Controllers\Security\VoidAuthenticationService;
+use TheCodingMachine\GraphQL\Controllers\Security\VoidAuthorizationService;
 use Youshido\GraphQL\Type\InputObject\InputObjectType;
 use Youshido\GraphQL\Type\InputTypeInterface;
 use Youshido\GraphQL\Type\Object\ObjectType;
@@ -17,6 +23,7 @@ abstract class AbstractQueryProviderTest extends TestCase
     private $inputTestObjectType;
     private $typeMapper;
     private $hydrator;
+    private $registry;
 
     protected function getTestObjectType()
     {
@@ -96,5 +103,24 @@ abstract class AbstractQueryProviderTest extends TestCase
             };
         }
         return $this->hydrator;
+    }
+
+    protected function getRegistry()
+    {
+        if ($this->registry === null) {
+            $this->registry = $this->buildRegistry(new EmptyContainer());
+        }
+        return $this->registry;
+    }
+
+    protected function buildRegistry(ContainerInterface $container)
+    {
+        $reader = new AnnotationReader();
+        return new Registry($container,
+                new VoidAuthorizationService(),
+                new VoidAuthenticationService(),
+                $reader,
+                $this->getTypeMapper(),
+                $this->getHydrator());
     }
 }

--- a/tests/AggregateControllerQueryProviderTest.php
+++ b/tests/AggregateControllerQueryProviderTest.php
@@ -16,7 +16,6 @@ class AggregateControllerQueryProviderTest extends AbstractQueryProviderTest
     public function testAggregate()
     {
         $controller = new TestController();
-        $reader = new AnnotationReader();
 
         $container = new class([ 'controller' => $controller ]) implements ContainerInterface {
 
@@ -41,7 +40,7 @@ class AggregateControllerQueryProviderTest extends AbstractQueryProviderTest
             }
         };
 
-        $aggregateQueryProvider = new AggregateControllerQueryProvider([ 'controller' ], $container, $reader, $this->getTypeMapper(), $this->getHydrator(), new VoidAuthenticationService(), new VoidAuthorizationService());
+        $aggregateQueryProvider = new AggregateControllerQueryProvider([ 'controller' ], $this->getRegistry(), $container);
 
         $queries = $aggregateQueryProvider->getQueries();
         $this->assertCount(2, $queries);

--- a/tests/AnnotatedObjectTypeTest.php
+++ b/tests/AnnotatedObjectTypeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+
+use TheCodingMachine\GraphQL\Controllers\Fixtures\TestObject;
+use TheCodingMachine\GraphQL\Controllers\Fixtures\TestType;
+use Youshido\GraphQL\Execution\ResolveInfo;
+
+class AnnotatedObjectTypeTest extends AbstractQueryProviderTest
+{
+    public function testBuild()
+    {
+        $type = new TestType($this->getRegistry());
+        $obj = new TestObject('bar');
+        $mockResolveInfo = $this->createMock(ResolveInfo::class);
+
+        $result = $type->getField('customField')->resolve($obj, ['param' => 'foo'], $mockResolveInfo);
+
+        $this->assertSame('barfoo', $result);
+    }
+}

--- a/tests/ControllerQueryProviderTest.php
+++ b/tests/ControllerQueryProviderTest.php
@@ -27,9 +27,8 @@ class ControllerQueryProviderTest extends AbstractQueryProviderTest
     public function testQueryProvider()
     {
         $controller = new TestController();
-        $reader = new AnnotationReader();
 
-        $queryProvider = new ControllerQueryProvider($controller, $reader, $this->getTypeMapper(), $this->getHydrator(), new VoidAuthenticationService(), new VoidAuthorizationService());
+        $queryProvider = new ControllerQueryProvider($controller, $this->getRegistry());
 
         $queries = $queryProvider->getQueries();
 
@@ -78,9 +77,8 @@ class ControllerQueryProviderTest extends AbstractQueryProviderTest
     public function testMutations()
     {
         $controller = new TestController();
-        $reader = new AnnotationReader();
 
-        $queryProvider = new ControllerQueryProvider($controller, $reader, $this->getTypeMapper(), $this->getHydrator(), new VoidAuthenticationService(), new VoidAuthorizationService());
+        $queryProvider = new ControllerQueryProvider($controller, $this->getRegistry());
 
         $mutations = $queryProvider->getMutations();
 
@@ -109,9 +107,8 @@ class ControllerQueryProviderTest extends AbstractQueryProviderTest
                 return 'foo';
             }
         };
-        $reader = new AnnotationReader();
 
-        $queryProvider = new ControllerQueryProvider($controller, $reader, $this->getTypeMapper(), $this->getHydrator(), new VoidAuthenticationService(), new VoidAuthorizationService());
+        $queryProvider = new ControllerQueryProvider($controller, $this->getRegistry());
 
         $this->expectException(MissingTypeHintException::class);
         $queryProvider->getQueries();
@@ -120,9 +117,8 @@ class ControllerQueryProviderTest extends AbstractQueryProviderTest
     public function testQueryProviderWithFixedReturnType()
     {
         $controller = new TestController();
-        $reader = new AnnotationReader();
 
-        $queryProvider = new ControllerQueryProvider($controller, $reader, $this->getTypeMapper(), $this->getHydrator(), new VoidAuthenticationService(), new VoidAuthorizationService());
+        $queryProvider = new ControllerQueryProvider($controller, $this->getRegistry());
 
         $queries = $queryProvider->getQueries();
 

--- a/tests/Fixtures/TestType.php
+++ b/tests/Fixtures/TestType.php
@@ -3,21 +3,28 @@
 
 namespace TheCodingMachine\GraphQL\Controllers\Fixtures;
 
+use TheCodingMachine\GraphQL\Controllers\AbstractAnnotatedObjectType;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Field;
 use TheCodingMachine\GraphQL\Controllers\Registry\Registry;
+use TheCodingMachine\GraphQL\Controllers\Registry\RegistryInterface;
 use Youshido\GraphQL\Config\Object\ObjectTypeConfig;
 use Youshido\GraphQL\Type\Object\AbstractObjectType;
 
-class TestType extends AbstractObjectType
+class TestType extends AbstractAnnotatedObjectType
 {
-    public function __construct(Registry $registry)
+    public function __construct(RegistryInterface $registry)
     {
-        parent::__construct([]);
+        parent::__construct($registry);
     }
 
     /**
-     * @param ObjectTypeConfig $config
+     * @Field()
+     * @param TestObject $test
+     * @param string $param
+     * @return string
      */
-    public function build($config)
+    public function customField(TestObject $test, string $param = 'foo'): string
     {
+        return $test->getTest().$param;
     }
 }

--- a/tests/Registry/RegistryTest.php
+++ b/tests/Registry/RegistryTest.php
@@ -4,10 +4,11 @@ namespace TheCodingMachine\GraphQL\Controllers\Registry;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use TheCodingMachine\GraphQL\Controllers\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\TestType;
 use TheCodingMachine\GraphQL\Controllers\Security\AuthorizationServiceInterface;
 
-class RegistryTest extends TestCase
+class RegistryTest extends AbstractQueryProviderTest
 {
     private function getContainer(): ContainerInterface
     {
@@ -26,7 +27,7 @@ class RegistryTest extends TestCase
 
     public function testFromContainer()
     {
-        $registry = new Registry($this->getContainer());
+        $registry = $this->buildRegistry($this->getContainer());
 
         $this->assertTrue($registry->has('foo'));
         $this->assertFalse($registry->has('bar'));
@@ -36,7 +37,7 @@ class RegistryTest extends TestCase
 
     public function testInstantiate()
     {
-        $registry = new Registry($this->getContainer());
+        $registry = $this->buildRegistry($this->getContainer());
 
         $this->assertTrue($registry->has(TestType::class));
         $type = $registry->get(TestType::class);
@@ -47,12 +48,12 @@ class RegistryTest extends TestCase
 
     public function testNotFound()
     {
-        $registry = new Registry($this->getContainer());
+        $registry = $this->buildRegistry($this->getContainer());
         $this->expectException(NotFoundException::class);
         $registry->get('notfound');
     }
 
-    public function testGetAuthorization()
+    /*public function testGetAuthorization()
     {
         $authorizationService = $this->createMock(AuthorizationServiceInterface::class);
         $registry = new Registry($this->getContainer(), $authorizationService);
@@ -62,5 +63,5 @@ class RegistryTest extends TestCase
         $registry = new Registry($this->getContainer());
 
         $this->assertNull($registry->getAuthorizationService());
-    }
+    }*/
 }


### PR DESCRIPTION
Adding a @Field annotation to customize types easily. This can be used by extending `AbstractAnnotatedObjectType`

TODO:

- [x] Documentation
- [ ] Modify TDBM-Graphql package accordingly