### PR TITLE
Adding @ExposedField annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ class PostType extends AbstractAnnotatedObjectType
 }
 ```
 
-The @ExposedField annotation
+The @SourceField annotation
 ----------------------------
 
 If your object has a lot of getters, you might end up in your type class mapping a lot of redundant code:
@@ -273,17 +273,17 @@ GraphQL-controllers provides a shortcut for this:
 ```php
 /**
  * @Type(class=Post::class)
- * @ExposedField(name="name")
+ * @SourceField(name="name")
  */
 class PostType extends AbstractAnnotatedObjectType
 {
 }
 ```
 
-By putting the `@ExposedField` in the class docblock, you let GraphQL-controllers now that the type should expose the
+By putting the `@SourceField` in the class docblock, you let GraphQL-controllers now that the type should expose the
 `getName` method of the underlying `Post` object.
 
-For the `@ExposedField` annotation to work, you need to add a `@Type` annotation that will let the GraphQL-controllers
+For the `@SourceField` annotation to work, you need to add a `@Type` annotation that will let the GraphQL-controllers
 library now the underlying type.
 
 Troubleshooting

--- a/README.md
+++ b/README.md
@@ -250,6 +250,42 @@ class PostType extends AbstractAnnotatedObjectType
 }
 ```
 
+The @ExposedField annotation
+----------------------------
+
+If your object has a lot of getters, you might end up in your type class mapping a lot of redundant code:
+
+```php
+class PostType extends AbstractAnnotatedObjectType
+{
+    /**
+     * @Field(name="name")
+     */
+    public function getName(Post $source): string
+    {
+        return $source->getName();
+    }
+}
+```
+
+GraphQL-controllers provides a shortcut for this:
+
+```php
+/**
+ * @Type(class=Post::class)
+ * @ExposedField(name="name")
+ */
+class PostType extends AbstractAnnotatedObjectType
+{
+}
+```
+
+By putting the `@ExposedField` in the class docblock, you let GraphQL-controllers now that the type should expose the
+`getName` method of the underlying `Post` object.
+
+For the `@ExposedField` annotation to work, you need to add a `@Type` annotation that will let the GraphQL-controllers
+library now the underlying type.
+
 Troubleshooting
 ---------------
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,21 @@ By putting the `@SourceField` in the class docblock, you let GraphQL-controllers
 For the `@SourceField` annotation to work, you need to add a `@Type` annotation that will let the GraphQL-controllers
 library now the underlying type.
 
+You can also check for logged users or users with a specific right using the `logged` and `right` properties of the annotation:
+
+```php
+/**
+ * @Type(class=Post::class)
+ * @SourceField(name="name")
+ * @SourceField(name="status", logged=true, right=@Right(name="CAN_ACCESS_STATUS"))
+ */
+class PostType extends AbstractAnnotatedObjectType
+{
+}
+```
+
+
+
 Troubleshooting
 ---------------
 

--- a/src/AggregateControllerQueryProvider.php
+++ b/src/AggregateControllerQueryProvider.php
@@ -7,6 +7,7 @@ use phpDocumentor\Reflection\Types\Mixed;
 use Psr\Container\ContainerInterface;
 use TheCodingMachine\GraphQL\Controllers\Registry\RegistryInterface;
 use Youshido\GraphQL\Field\Field;
+use Youshido\GraphQL\Field\FieldInterface;
 
 /**
  * A query provider that looks into all controllers of your application to fetch queries.
@@ -39,7 +40,7 @@ class AggregateControllerQueryProvider implements QueryProviderInterface
     }
 
     /**
-     * @return Field[]
+     * @return FieldInterface[]
      */
     public function getQueries(): array
     {
@@ -55,7 +56,7 @@ class AggregateControllerQueryProvider implements QueryProviderInterface
     }
 
     /**
-     * @return Field[]
+     * @return FieldInterface[]
      */
     public function getMutations(): array
     {

--- a/src/Annotations/ExposedField.php
+++ b/src/Annotations/ExposedField.php
@@ -1,0 +1,90 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Annotations;
+
+/**
+ * ExposedFields are fields that are directly exposed from the base object into GraphQL.
+ *
+ * @Annotation
+ * @Target({"CLASS"})
+ * @Attributes({
+ *   @Attribute("name", type = "string"),
+ *   @Attribute("logged", type = "bool"),
+ *   @Attribute("right", type = Right::class),
+ *   @Attribute("returnType", type = "string"),
+ * })
+ */
+class ExposedField
+{
+    /**
+     * @var Right|null
+     */
+    private $right;
+
+    /**
+     * @var string|null
+     */
+    private $name;
+
+    /**
+     * @var bool
+     */
+    private $logged;
+
+    /**
+     * @var string|null
+     */
+    private $returnType;
+
+    /**
+     * @param mixed[] $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        $this->name = $attributes['name'] ?? null;
+        $this->logged = $attributes['logged'] ?? false;
+        $this->right = $attributes['right'] ?? null;
+        $this->returnType = $attributes['returnType'] ?? null;
+    }
+
+    /**
+     * Returns the GraphQL right to be applied to this exposed field.
+     *
+     * @return Right|null
+     */
+    public function getRight(): ?Right
+    {
+        return $this->right;
+    }
+
+    /**
+     * Returns the name of the GraphQL query/mutation/field.
+     * If not specified, the name of the method should be used instead.
+     *
+     * @return null|string
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLogged(): bool
+    {
+        return $this->logged;
+    }
+
+    /**
+     * Returns the GraphQL return type of the request (as a string).
+     * The string can represent the FQCN of the type or an entry in the container resolving to the GraphQL type.
+     *
+     * @return string|null
+     */
+    public function getReturnType(): ?string
+    {
+        return $this->returnType;
+    }
+}

--- a/src/Annotations/Field.php
+++ b/src/Annotations/Field.php
@@ -5,6 +5,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Annotations;
 
 /**
  * @Annotation
+ * @Target({"METHOD"})
  * @Attributes({
  *   @Attribute("returnType", type = "string"),
  * })

--- a/src/Annotations/Mutation.php
+++ b/src/Annotations/Mutation.php
@@ -5,6 +5,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Annotations;
 
 /**
  * @Annotation
+ * @Target({"METHOD"})
  * @Attributes({
  *   @Attribute("returnType", type = "string"),
  * })

--- a/src/Annotations/Query.php
+++ b/src/Annotations/Query.php
@@ -5,6 +5,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Annotations;
 
 /**
  * @Annotation
+ * @Target({"METHOD"})
  * @Attributes({
  *   @Attribute("returnType", type = "string"),
  * })

--- a/src/Annotations/Right.php
+++ b/src/Annotations/Right.php
@@ -5,7 +5,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Annotations;
 
 /**
  * @Annotation
- * @Target({"METHOD"})
+ * @Target({"ANNOTATION", "METHOD"})
  * @Attributes({
  *   @Attribute("name", type = "string"),
  * })

--- a/src/Annotations/SourceField.php
+++ b/src/Annotations/SourceField.php
@@ -4,7 +4,7 @@
 namespace TheCodingMachine\GraphQL\Controllers\Annotations;
 
 /**
- * ExposedFields are fields that are directly exposed from the base object into GraphQL.
+ * SourceFields are fields that are directly source from the base object into GraphQL.
  *
  * @Annotation
  * @Target({"CLASS"})
@@ -15,7 +15,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Annotations;
  *   @Attribute("returnType", type = "string"),
  * })
  */
-class ExposedField
+class SourceField
 {
     /**
      * @var Right|null
@@ -49,7 +49,7 @@ class ExposedField
     }
 
     /**
-     * Returns the GraphQL right to be applied to this exposed field.
+     * Returns the GraphQL right to be applied to this source field.
      *
      * @return Right|null
      */

--- a/src/Annotations/SourceField.php
+++ b/src/Annotations/SourceField.php
@@ -11,7 +11,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Annotations;
  * @Attributes({
  *   @Attribute("name", type = "string"),
  *   @Attribute("logged", type = "bool"),
- *   @Attribute("right", type = Right::class),
+ *   @Attribute("right", type = "TheCodingMachine\GraphQL\Controllers\Annotations\Right"),
  *   @Attribute("returnType", type = "string"),
  * })
  */

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Annotations;
+
+use TheCodingMachine\GraphQL\Controllers\MissingAnnotationException;
+
+/**
+ * The Type annotation must be put in a GraphQL type class docblock and is used to map to the underlying PHP class
+ * this is exposed via this type.
+ *
+ * @Annotation
+ * @Target({"CLASS"})
+ * @Attributes({
+ *   @Attribute("class", type = "string"),
+ * })
+ */
+class Type
+{
+    /**
+     * @var string|null
+     */
+    private $className;
+
+    /**
+     * @param mixed[] $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        if (!isset($attributes['class'])) {
+            throw new MissingAnnotationException('In annotation @Type, missing compulsory parameter "class".');
+        }
+        $this->className = $attributes['class'];
+    }
+
+    /**
+     * Returns the name of the GraphQL query/mutation/field.
+     * If not specified, the name of the method should be used instead.
+     *
+     * @return string
+     */
+    public function getClass(): string
+    {
+        return $this->className;
+    }
+}

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -18,7 +18,7 @@ use TheCodingMachine\GraphQL\Controllers\MissingAnnotationException;
 class Type
 {
     /**
-     * @var string|null
+     * @var string
      */
     private $className;
 

--- a/src/ControllerQueryProvider.php
+++ b/src/ControllerQueryProvider.php
@@ -17,6 +17,7 @@ use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Doctrine\Common\Annotations\Reader;
 use phpDocumentor\Reflection\Types\Integer;
 use TheCodingMachine\GraphQL\Controllers\Annotations\AbstractRequest;
+use TheCodingMachine\GraphQL\Controllers\Annotations\ExposedField;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Logged;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Mutation;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Query;
@@ -106,7 +107,10 @@ class ControllerQueryProvider implements QueryProviderInterface
      */
     public function getFields(): array
     {
-        return $this->getFieldsByAnnotations(Annotations\Field::class, true);
+        $fieldAnnotations = $this->getFieldsByAnnotations(Annotations\Field::class, true);
+        $exposedFields = $this->getExposedFields();
+
+        return array_merge($fieldAnnotations, $exposedFields);
     }
 
     /**
@@ -130,10 +134,10 @@ class ControllerQueryProvider implements QueryProviderInterface
             /* @var $queryAnnotation AbstractRequest */
 
             if ($queryAnnotation !== null) {
-                $docBlock = new CommentParser($refMethod->getDocComment());
                 if (!$this->isAuthorized($standardPhpMethod)) {
                     continue;
                 }
+                $docBlock = new CommentParser($refMethod->getDocComment());
 
                 $methodName = $refMethod->getName();
                 $name = $queryAnnotation->getName() ?: $methodName;
@@ -160,11 +164,96 @@ class ControllerQueryProvider implements QueryProviderInterface
                     /* @var $sourceType TypeInterface */
                     // TODO
                 }
-                $queryList[] = new QueryField($name, $type, $args, [$this->controller, $methodName], $this->hydrator, $docBlock->getComment(), $injectSource);
+                $queryList[] = new QueryField($name, $type, $args, [$this->controller, $methodName], null, $this->hydrator, $docBlock->getComment(), $injectSource);
             }
         }
 
         return $queryList;
+    }
+
+    /**
+     * @return QueryField[]
+     */
+    private function getExposedFields(): array
+    {
+        $refClass = new \ReflectionClass($this->controller);
+
+        /** @var ExposedField[] $exposedFields */
+        $exposedFields = $this->annotationReader->getClassAnnotations($refClass);
+        $exposedFields = \array_filter($exposedFields, function($annotation): bool {
+            return $annotation instanceof ExposedField;
+        });
+
+        if (empty($exposedFields)) {
+            return [];
+        }
+
+        /** @var \TheCodingMachine\GraphQL\Controllers\Annotations\Type $typeField */
+        $typeField = $this->annotationReader->getClassAnnotation($refClass, \TheCodingMachine\GraphQL\Controllers\Annotations\Type::class);
+
+        if ($typeField === null) {
+            throw MissingAnnotationException::missingTypeException();
+        }
+
+        $objectClass = $typeField->getClass();
+        $objectRefClass = ReflectionClass::createFromName($objectClass);
+
+        $typeResolver = new \phpDocumentor\Reflection\TypeResolver();
+
+        foreach ($exposedFields as $exposedField) {
+            // Ignore the field if we must be logged.
+            if ($exposedField->isLogged() && !$this->authenticationService->isLogged()) {
+                continue;
+            }
+
+            $right = $exposedField->getRight();
+            if ($right !== null && !$this->authorizationService->isAllowed($right->getName())) {
+                continue;
+            }
+
+            try {
+                $refMethod = $this->getMethodFromPropertyName($objectRefClass, $exposedField->getName());
+            } catch (FieldNotFoundException $e) {
+                throw FieldNotFoundException::wrapWithCallerInfo($e, $refClass->getName());
+            }
+
+            $docBlock = new CommentParser($refMethod->getDocComment());
+
+            $methodName = $refMethod->getName();
+
+            $standardPhpMethod = new \ReflectionMethod($objectRefClass->getName(), $refMethod->getName());
+            $args = $this->mapParameters($refMethod, $standardPhpMethod);
+
+            $phpdocType = $typeResolver->resolve((string) $refMethod->getReturnType());
+
+            if ($exposedField->getReturnType()) {
+                $type = $this->registry->get($exposedField->getReturnType());
+            } else {
+                try {
+                    $type = $this->mapType($phpdocType, $refMethod->getDocBlockReturnTypes(), $standardPhpMethod->getReturnType()->allowsNull(), false);
+                } catch (TypeMappingException $e) {
+                    throw TypeMappingException::wrapWithReturnInfo($e, $refMethod);
+                }
+            }
+
+            $queryList[] = new QueryField($exposedField->getName(), $type, $args, null, $methodName, $this->hydrator, $docBlock->getComment(), false);
+
+        }
+        return $queryList;
+    }
+
+    private function getMethodFromPropertyName(ReflectionClass $reflectionClass, string $propertyName): ReflectionMethod
+    {
+        $upperCasePropertyName = \ucfirst($propertyName);
+        if ($reflectionClass->hasMethod('get'.$upperCasePropertyName)) {
+            $methodName = 'get'.$upperCasePropertyName;
+        } elseif ($reflectionClass->hasMethod('is'.$upperCasePropertyName)) {
+            $methodName = 'is'.$upperCasePropertyName;
+        } else {
+            throw FieldNotFoundException::missingField($reflectionClass->getName(), $propertyName);
+        }
+
+        return $reflectionClass->getMethod($methodName);
     }
 
     /**

--- a/src/FieldNotFoundException.php
+++ b/src/FieldNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+
+class FieldNotFoundException extends \RuntimeException
+{
+    public static function missingField(string $className, string $fieldName): self
+    {
+        throw new self(sprintf('Could not find a getter or a isser for field "%s". Looked for: "%s::get%s()", "%s::is%s()"',
+            $fieldName, $className, \ucfirst($fieldName), $className, \ucfirst($fieldName)));
+    }
+
+    public static function wrapWithCallerInfo(self $e, string $className): self
+    {
+        throw new self(sprintf('There is an issue with a @ExposedField annotation in class "%s": %s',
+            $className, $e->getMessage()), 0, $e);
+    }
+}

--- a/src/FieldNotFoundException.php
+++ b/src/FieldNotFoundException.php
@@ -14,7 +14,7 @@ class FieldNotFoundException extends \RuntimeException
 
     public static function wrapWithCallerInfo(self $e, string $className): self
     {
-        throw new self(sprintf('There is an issue with a @ExposedField annotation in class "%s": %s',
+        throw new self(sprintf('There is an issue with a @SourceField annotation in class "%s": %s',
             $className, $e->getMessage()), 0, $e);
     }
 }

--- a/src/MissingAnnotationException.php
+++ b/src/MissingAnnotationException.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+
+class MissingAnnotationException extends \RuntimeException
+{
+    public static function missingTypeException(): self
+    {
+        return new self('You cannot use the @ExposedField annotation without also adding a @Type annotation.');
+    }
+}

--- a/src/MissingAnnotationException.php
+++ b/src/MissingAnnotationException.php
@@ -8,6 +8,6 @@ class MissingAnnotationException extends \RuntimeException
 {
     public static function missingTypeException(): self
     {
-        return new self('You cannot use the @ExposedField annotation without also adding a @Type annotation.');
+        return new self('You cannot use the @SourceField annotation without also adding a @Type annotation.');
     }
 }

--- a/src/QueryProviderInterface.php
+++ b/src/QueryProviderInterface.php
@@ -3,7 +3,7 @@
 
 namespace TheCodingMachine\GraphQL\Controllers;
 
-use Youshido\GraphQL\Field\Field;
+use Youshido\GraphQL\Field\FieldInterface;
 
 /**
  * Returns a list of queries to be put in the GraphQL schema
@@ -11,12 +11,12 @@ use Youshido\GraphQL\Field\Field;
 interface QueryProviderInterface
 {
     /**
-     * @return Field[]
+     * @return FieldInterface[]
      */
     public function getQueries(): array;
 
     /**
-     * @return Field[]
+     * @return FieldInterface[]
      */
     public function getMutations(): array;
 }

--- a/tests/ControllerQueryProviderTest.php
+++ b/tests/ControllerQueryProviderTest.php
@@ -143,7 +143,7 @@ class ControllerQueryProviderTest extends AbstractQueryProviderTest
         $this->assertSame('nameFromAnnotation', $query->getName());
     }
 
-    public function testExposedField()
+    public function testSourceField()
     {
         $controller = new TestType($this->getRegistry());
 
@@ -165,12 +165,12 @@ class ControllerQueryProviderTest extends AbstractQueryProviderTest
         $queryProvider->getFields();
     }
 
-    public function testExposedFieldDoesNotExists()
+    public function testSourceFieldDoesNotExists()
     {
         $queryProvider = new ControllerQueryProvider(new TestTypeMissingField(), $this->getRegistry());
 
         $this->expectException(FieldNotFoundException::class);
-        $this->expectExceptionMessage("There is an issue with a @ExposedField annotation in class \"TheCodingMachine\GraphQL\Controllers\Fixtures\TestTypeMissingField\": Could not find a getter or a isser for field \"notExists\". Looked for: \"TheCodingMachine\GraphQL\Controllers\Fixtures\TestObject::getNotExists()\", \"TheCodingMachine\GraphQL\Controllers\Fixtures\TestObject::isNotExists()");
+        $this->expectExceptionMessage("There is an issue with a @SourceField annotation in class \"TheCodingMachine\GraphQL\Controllers\Fixtures\TestTypeMissingField\": Could not find a getter or a isser for field \"notExists\". Looked for: \"TheCodingMachine\GraphQL\Controllers\Fixtures\TestObject::getNotExists()\", \"TheCodingMachine\GraphQL\Controllers\Fixtures\TestObject::isNotExists()");
         $queryProvider->getFields();
     }
 }

--- a/tests/Fixtures/TestObject.php
+++ b/tests/Fixtures/TestObject.php
@@ -9,10 +9,15 @@ class TestObject
      * @var string
      */
     private $test;
+    /**
+     * @var bool
+     */
+    private $testBool;
 
-    public function __construct(string $test)
+    public function __construct(string $test, bool $testBool = false)
     {
         $this->test = $test;
+        $this->testBool = $testBool;
     }
 
     /**
@@ -21,5 +26,13 @@ class TestObject
     public function getTest(): string
     {
         return $this->test;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTestBool(): bool
+    {
+        return $this->testBool;
     }
 }

--- a/tests/Fixtures/TestObject.php
+++ b/tests/Fixtures/TestObject.php
@@ -35,4 +35,9 @@ class TestObject
     {
         return $this->testBool;
     }
+
+    public function getTestRight(): string
+    {
+        return "foo";
+    }
 }

--- a/tests/Fixtures/TestType.php
+++ b/tests/Fixtures/TestType.php
@@ -4,7 +4,7 @@
 namespace TheCodingMachine\GraphQL\Controllers\Fixtures;
 
 use TheCodingMachine\GraphQL\Controllers\AbstractAnnotatedObjectType;
-use TheCodingMachine\GraphQL\Controllers\Annotations\ExposedField;
+use TheCodingMachine\GraphQL\Controllers\Annotations\SourceField;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Field;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Type;
 use TheCodingMachine\GraphQL\Controllers\Registry\Registry;
@@ -14,8 +14,8 @@ use Youshido\GraphQL\Type\Object\AbstractObjectType;
 
 /**
  * @Type(class=TestObject::class)
- * @ExposedField(name="test")
- * @ExposedField(name="testBool")
+ * @SourceField(name="test")
+ * @SourceField(name="testBool")
  */
 class TestType extends AbstractAnnotatedObjectType
 {

--- a/tests/Fixtures/TestType.php
+++ b/tests/Fixtures/TestType.php
@@ -4,12 +4,19 @@
 namespace TheCodingMachine\GraphQL\Controllers\Fixtures;
 
 use TheCodingMachine\GraphQL\Controllers\AbstractAnnotatedObjectType;
+use TheCodingMachine\GraphQL\Controllers\Annotations\ExposedField;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Field;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Type;
 use TheCodingMachine\GraphQL\Controllers\Registry\Registry;
 use TheCodingMachine\GraphQL\Controllers\Registry\RegistryInterface;
 use Youshido\GraphQL\Config\Object\ObjectTypeConfig;
 use Youshido\GraphQL\Type\Object\AbstractObjectType;
 
+/**
+ * @Type(class=TestObject::class)
+ * @ExposedField(name="test")
+ * @ExposedField(name="testBool")
+ */
 class TestType extends AbstractAnnotatedObjectType
 {
     public function __construct(RegistryInterface $registry)

--- a/tests/Fixtures/TestType.php
+++ b/tests/Fixtures/TestType.php
@@ -4,6 +4,7 @@
 namespace TheCodingMachine\GraphQL\Controllers\Fixtures;
 
 use TheCodingMachine\GraphQL\Controllers\AbstractAnnotatedObjectType;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Right;
 use TheCodingMachine\GraphQL\Controllers\Annotations\SourceField;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Field;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Type;
@@ -15,7 +16,8 @@ use Youshido\GraphQL\Type\Object\AbstractObjectType;
 /**
  * @Type(class=TestObject::class)
  * @SourceField(name="test")
- * @SourceField(name="testBool")
+ * @SourceField(name="testBool", logged=true)
+ * @SourceField(name="testRight", right=@Right(name="FOOBAR"))
  */
 class TestType extends AbstractAnnotatedObjectType
 {

--- a/tests/Fixtures/TestTypeMissingAnnotation.php
+++ b/tests/Fixtures/TestTypeMissingAnnotation.php
@@ -3,10 +3,10 @@
 
 namespace TheCodingMachine\GraphQL\Controllers\Fixtures;
 
-use TheCodingMachine\GraphQL\Controllers\Annotations\ExposedField;
+use TheCodingMachine\GraphQL\Controllers\Annotations\SourceField;
 
 /**
- * @ExposedField(name="test")
+ * @SourceField(name="test")
  */
 class TestTypeMissingAnnotation
 {

--- a/tests/Fixtures/TestTypeMissingAnnotation.php
+++ b/tests/Fixtures/TestTypeMissingAnnotation.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Fixtures;
+
+use TheCodingMachine\GraphQL\Controllers\Annotations\ExposedField;
+
+/**
+ * @ExposedField(name="test")
+ */
+class TestTypeMissingAnnotation
+{
+}

--- a/tests/Fixtures/TestTypeMissingField.php
+++ b/tests/Fixtures/TestTypeMissingField.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Fixtures;
+
+use TheCodingMachine\GraphQL\Controllers\Annotations\ExposedField;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Type;
+
+/**
+ * @Type(class=TestObject::class)
+ * @ExposedField(name="notExists")
+ */
+class TestTypeMissingField
+{
+}

--- a/tests/Fixtures/TestTypeMissingField.php
+++ b/tests/Fixtures/TestTypeMissingField.php
@@ -3,12 +3,12 @@
 
 namespace TheCodingMachine\GraphQL\Controllers\Fixtures;
 
-use TheCodingMachine\GraphQL\Controllers\Annotations\ExposedField;
+use TheCodingMachine\GraphQL\Controllers\Annotations\SourceField;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Type;
 
 /**
  * @Type(class=TestObject::class)
- * @ExposedField(name="notExists")
+ * @SourceField(name="notExists")
  */
 class TestTypeMissingField
 {


### PR DESCRIPTION
The @ExposedField can be used to quickly expose a field in the underlying object:

```php
/**
 * @Type(class=Post::class)
 * @ExposedField(name="name")
 */
class PostType extends AbstractAnnotatedObjectType
{
}
```