### PR TITLE
Autodetecting controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ $queryProvider = new AggregateControllerQueryProvider([
   );
 ```
 
+Alternatively, you can use auto-discovery of the controllers if you put them in a common namespace:
+
+```php
+$queryProvider = new GlobControllerQueryProvider('App\\GraphQL\\Controllers', $this->getRegistry(), $container, $cache, $cacheTtl);
+```
+
+The application will look into the 'App\\GraphQL\\Controllers' namespace for GraphQL controllers. It assumes that the 
+container contains an entry whose name is the fully qualified class name of the container.
+Note: $cache is a PSR-16 compatible cache.
 
 Defining object types
 =====================

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "satooshi/php-coveralls": "^1.0",
         "symfony/cache": "^4.1.4",
         "mouf/picotainer": "^1.1",
-        "phpstan/phpstan": "^0.10.3"
+        "phpstan/phpstan": "^0.10.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,5 @@
 parameters:
     ignoreErrors:
         - "#PHPDoc tag \\@throws with type Psr\\\\Container\\\\ContainerExceptionInterface is not subtype of Throwable#"
-        # See https://github.com/phpstan/phpstan/pull/1439
-        - "#Strict comparison using === between ReflectionType and null will always evaluate to false#"
 #includes:
 #    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/AggregateQueryProvider.php
+++ b/src/AggregateQueryProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+use function array_map;
+use function array_merge;
+
+/**
+ * A query provider that aggregates several query providers together.
+ */
+class AggregateQueryProvider implements QueryProviderInterface
+{
+    /**
+     * @var QueryProviderInterface[]
+     */
+    private $queryProviders;
+
+    /**
+     * @param QueryProviderInterface[] $queryProviders
+     */
+    public function __construct(array $queryProviders)
+    {
+        $this->queryProviders = $queryProviders;
+    }
+
+    /**
+     * @return QueryField[]
+     */
+    public function getQueries(): array
+    {
+        $queriesArray = array_map(function(QueryProviderInterface $queryProvider) { return $queryProvider->getQueries(); }, $this->queryProviders);
+        if ($queriesArray === []) {
+            return [];
+        }
+        return array_merge(...$queriesArray);
+    }
+
+    /**
+     * @return QueryField[]
+     */
+    public function getMutations(): array
+    {
+        $mutationsArray = array_map(function(QueryProviderInterface $queryProvider) { return $queryProvider->getMutations(); }, $this->queryProviders);
+        if ($mutationsArray === []) {
+            return [];
+        }
+        return array_merge(...$mutationsArray);
+    }
+}

--- a/src/GlobControllerQueryProvider.php
+++ b/src/GlobControllerQueryProvider.php
@@ -1,0 +1,135 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+use Doctrine\Common\Annotations\Reader;
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\OutputType;
+use Mouf\Composer\ClassNameMapper;
+use Psr\Container\ContainerInterface;
+use Psr\SimpleCache\CacheInterface;
+use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
+use TheCodingMachine\GraphQL\Controllers\AggregateControllerQueryProvider;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Type;
+use TheCodingMachine\GraphQL\Controllers\AnnotationUtils;
+use TheCodingMachine\GraphQL\Controllers\QueryField;
+use TheCodingMachine\GraphQL\Controllers\QueryProviderInterface;
+use TheCodingMachine\GraphQL\Controllers\Registry\RegistryInterface;
+use TheCodingMachine\GraphQL\Controllers\TypeGenerator;
+
+/**
+ * Scans all the classes in a given namespace of the main project (not the vendor directory).
+ * Analyzes all classes and detects "Query" and "Mutation" annotations.
+ *
+ * Assumes that the container contains a class whose identifier is the same as the class name.
+ */
+final class GlobControllerQueryProvider implements QueryProviderInterface
+{
+    /**
+     * @var string
+     */
+    private $namespace;
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+    /**
+     * @var int|null
+     */
+    private $cacheTtl;
+    /**
+     * @var array<string,string>|null
+     */
+    private $instancesList;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+    /**
+     * @var AggregateControllerQueryProvider
+     */
+    private $aggregateControllerQueryProvider;
+    /**
+     * @var RegistryInterface
+     */
+    private $registry;
+
+    /**
+     * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
+     * @param ContainerInterface|null $container The container we will fetch controllers from. If not specified, container from the registry is used instead.
+     */
+    public function __construct(string $namespace, RegistryInterface $registry, ?ContainerInterface $container, CacheInterface $cache, ?int $cacheTtl = null)
+    {
+        $this->namespace = $namespace;
+        $this->registry = $registry;
+        $this->container = $container ?: $registry;
+        $this->cache = $cache;
+        $this->cacheTtl = $cacheTtl;
+    }
+
+    private function getAggregateControllerQueryProvider(): AggregateControllerQueryProvider
+    {
+        if ($this->aggregateControllerQueryProvider === null) {
+            $this->aggregateControllerQueryProvider = new AggregateControllerQueryProvider($this->getInstancesList(), $this->registry, $this->container);
+        }
+        return $this->aggregateControllerQueryProvider;
+    }
+
+    /**
+     * Returns an array of fully qualified class names.
+     *
+     * @return string[]
+     */
+    private function getInstancesList(): array
+    {
+        if ($this->instancesList === null) {
+            $key = 'globQueryProvider_'.str_replace('\\', '_', $this->namespace);
+            $this->instancesList = $this->cache->get($key);
+            if ($this->instancesList === null) {
+                $this->instancesList = $this->buildInstancesList();
+                $this->cache->set($key, $this->instancesList, $this->cacheTtl);
+            }
+        }
+        return $this->instancesList;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function buildInstancesList(): array
+    {
+        $explorer = new GlobClassExplorer($this->namespace, $this->cache, $this->cacheTtl, ClassNameMapper::createFromComposerFile(null, null, true));
+        $classes = $explorer->getClasses();
+        $instances = [];
+        foreach ($classes as $className) {
+            if (!\class_exists($className)) {
+                continue;
+            }
+            $refClass = new \ReflectionClass($className);
+            if (!$refClass->isInstantiable()) {
+                continue;
+            }
+            if ($this->container->has($className)) {
+                $instances[] = $className;
+            }
+        }
+        return $instances;
+    }
+
+    /**
+     * @return QueryField[]
+     */
+    public function getQueries(): array
+    {
+        return $this->getAggregateControllerQueryProvider()->getQueries();
+    }
+
+    /**
+     * @return QueryField[]
+     */
+    public function getMutations(): array
+    {
+        return $this->getAggregateControllerQueryProvider()->getMutations();
+    }
+}

--- a/tests/AggregateQueryProviderTest.php
+++ b/tests/AggregateQueryProviderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class AggregateQueryProviderTest extends TestCase
+{
+    private function getMockQueryProvider(): QueryProviderInterface
+    {
+        return new class implements QueryProviderInterface {
+            public function getQueries(): array
+            {
+                $queryFieldRef = new ReflectionClass(QueryField::class);
+                return [ $queryFieldRef->newInstanceWithoutConstructor() ];
+            }
+
+            public function getMutations(): array
+            {
+                $queryFieldRef = new ReflectionClass(QueryField::class);
+                return [ $queryFieldRef->newInstanceWithoutConstructor() ];
+            }
+        };
+    }
+
+    public function testGetMutations()
+    {
+        $aggregateQueryProvider = new AggregateQueryProvider([$this->getMockQueryProvider(), $this->getMockQueryProvider()]);
+        $this->assertCount(2, $aggregateQueryProvider->getMutations());
+
+        $aggregateQueryProvider = new AggregateQueryProvider([]);
+        $this->assertCount(0, $aggregateQueryProvider->getMutations());
+    }
+
+    public function testGetQueries()
+    {
+        $aggregateQueryProvider = new AggregateQueryProvider([$this->getMockQueryProvider(), $this->getMockQueryProvider()]);
+        $this->assertCount(2, $aggregateQueryProvider->getQueries());
+
+        $aggregateQueryProvider = new AggregateQueryProvider([]);
+        $this->assertCount(0, $aggregateQueryProvider->getQueries());
+    }
+}

--- a/tests/GlobControllerQueryProviderTest.php
+++ b/tests/GlobControllerQueryProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Cache\Simple\NullCache;
+use TheCodingMachine\GraphQL\Controllers\Fixtures\TestController;
+
+class GlobControllerQueryProviderTest extends AbstractQueryProviderTest
+{
+    public function testGlob()
+    {
+        $controller = new TestController();
+
+        $container = new class([ TestController::class => $controller ]) implements ContainerInterface {
+            /**
+             * @var array
+             */
+            private $controllers;
+
+            public function __construct(array $controllers)
+            {
+                $this->controllers = $controllers;
+            }
+
+            public function get($id)
+            {
+                return $this->controllers[$id];
+            }
+
+            public function has($id)
+            {
+                return isset($this->controllers[$id]);
+            }
+        };
+
+        $globControllerQueryProvider = new GlobControllerQueryProvider('TheCodingMachine\\GraphQL\\Controllers', $this->getRegistry(), $container, new NullCache());
+
+        $queries = $globControllerQueryProvider->getQueries();
+        $this->assertCount(5, $queries);
+
+        $mutations = $globControllerQueryProvider->getMutations();
+        $this->assertCount(1, $mutations);
+
+    }
+}


### PR DESCRIPTION
This PR adds a class that can automatically detect GraphQL controllers in a given namespace.