### PR TITLE
Improving error message if a Query has no return type

### DIFF
--- a/tests/ControllerQueryProviderTest.php
+++ b/tests/ControllerQueryProviderTest.php
@@ -13,6 +13,7 @@ use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Definition\ObjectType;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\TestController;
+use TheCodingMachine\GraphQL\Controllers\Fixtures\TestControllerNoReturnType;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\TestObject;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\TestType;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\TestTypeId;
@@ -289,5 +290,12 @@ class ControllerQueryProviderTest extends AbstractQueryProviderTest
         $this->assertInstanceOf(NonNull::class, $iterableQuery->getType()->getWrappedType()->getWrappedType());
         $this->assertInstanceOf(ObjectType::class, $iterableQuery->getType()->getWrappedType()->getWrappedType()->getWrappedType());
         $this->assertSame('TestObject', $iterableQuery->getType()->getWrappedType()->getWrappedType()->getWrappedType()->name);
+    }
+
+    public function testNoReturnTypeError()
+    {
+        $queryProvider = new ControllerQueryProvider(new TestControllerNoReturnType(), $this->getRegistry());
+        $this->expectException(TypeMappingException::class);
+        $queryProvider->getQueries();
     }
 }

--- a/tests/Fixtures/TestControllerNoReturnType.php
+++ b/tests/Fixtures/TestControllerNoReturnType.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Fixtures;
+
+use ArrayObject;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Logged;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Mutation;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Query;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Right;
+
+class TestControllerNoReturnType
+{
+    /**
+     * @Query()
+     */
+    public function test()
+    {
+        return 'foo';
+    }
+}


### PR DESCRIPTION
A proper exception with an understandable error message is now thrown