### PR TITLE
Adding a type loader

### DIFF
--- a/src/Mappers/CannotMapTypeException.php
+++ b/src/Mappers/CannotMapTypeException.php
@@ -18,6 +18,11 @@ class CannotMapTypeException extends \Exception
         return new self('cannot map class "'.$className.'" to a known GraphQL input type. Check your TypeMapper configuration.');
     }
 
+    public static function createForName(string $name): self
+    {
+        return new self('cannot find GraphQL type "'.$name.'". Check your TypeMapper configuration.');
+    }
+
     public static function wrapWithParamInfo(self $previous, \ReflectionParameter $parameter): self
     {
         $message = sprintf('For parameter $%s, in %s::%s, %s',

--- a/src/Mappers/CompositeTypeMapper.php
+++ b/src/Mappers/CompositeTypeMapper.php
@@ -10,6 +10,7 @@ use function array_unique;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\Type;
 use function is_array;
 use function iterator_to_array;
 
@@ -114,5 +115,17 @@ class CompositeTypeMapper implements TypeMapperInterface
             }
         }
         throw CannotMapTypeException::createForInputType($className);
+    }
+
+    /**
+     * Returns a GraphQL type by name (can be either an input or output type)
+     *
+     * @param string $typeName The name of the GraphQL type
+     * @param RecursiveTypeMapperInterface $recursiveTypeMapper
+     * @return Type&(InputType|OutputType)
+     */
+    public function mapNameToType(string $typeName, RecursiveTypeMapperInterface $recursiveTypeMapper): Type
+    {
+        // TODO: Implement mapNameToType() method.
     }
 }

--- a/src/Mappers/CompositeTypeMapper.php
+++ b/src/Mappers/CompositeTypeMapper.php
@@ -126,6 +126,27 @@ class CompositeTypeMapper implements TypeMapperInterface
      */
     public function mapNameToType(string $typeName, RecursiveTypeMapperInterface $recursiveTypeMapper): Type
     {
-        // TODO: Implement mapNameToType() method.
+        foreach ($this->typeMappers as $typeMapper) {
+            if ($typeMapper->canMapNameToType($typeName)) {
+                return $typeMapper->mapNameToType($typeName, $recursiveTypeMapper);
+            }
+        }
+        throw CannotMapTypeException::createForName($typeName);
+    }
+
+    /**
+     * Returns true if this type mapper can map the $typeName GraphQL name to a GraphQL type.
+     *
+     * @param string $typeName The name of the GraphQL type
+     * @return bool
+     */
+    public function canMapNameToType(string $typeName): bool
+    {
+        foreach ($this->typeMappers as $typeMapper) {
+            if ($typeMapper->canMapNameToType($typeName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -294,4 +294,23 @@ final class GlobTypeMapper implements TypeMapperInterface
         }
         return $this->typeGenerator->mapAnnotatedObject($this->container->get($this->mapNameToType[$typeName]), $recursiveTypeMapper);
     }
+
+    /**
+     * Returns true if this type mapper can map the $typeName GraphQL name to a GraphQL type.
+     *
+     * @param string $typeName The name of the GraphQL type
+     * @return bool
+     */
+    public function canMapNameToType(string $typeName): bool
+    {
+        $typeClassName = $this->getTypeFromCacheByGraphQLTypeName($typeName);
+
+        if ($typeClassName !== null) {
+            return true;
+        }
+
+        $this->buildMap();
+
+        return isset($this->mapNameToType[$typeName]);
+    }
 }

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -165,7 +165,7 @@ final class GlobTypeMapper implements TypeMapperInterface
                 'typeClass' => $typeClassName
             ] = $item;
 
-            if ($filemtime === $filemtime($typeFileName)) {
+            if ($filemtime === filemtime($typeFileName)) {
                 $this->mapClassToTypeArray[$className] = $typeClassName;
                 return $typeClassName;
             }
@@ -190,7 +190,7 @@ final class GlobTypeMapper implements TypeMapperInterface
                 'typeClass' => $typeClassName
             ] = $item;
 
-            if ($filemtime === $filemtime($typeFileName)) {
+            if ($filemtime === filemtime($typeFileName)) {
                 $this->mapNameToType[$graphqlTypeName] = $typeClassName;
                 return $typeClassName;
             }

--- a/src/Mappers/RecursiveTypeMapperInterface.php
+++ b/src/Mappers/RecursiveTypeMapperInterface.php
@@ -74,4 +74,20 @@ interface RecursiveTypeMapperInterface
      * @return array<string, OutputType>
      */
     public function getOutputTypes(): array;
+
+    /**
+     * Returns true if this type mapper can map the $typeName GraphQL name to a GraphQL type.
+     *
+     * @param string $typeName The name of the GraphQL type
+     * @return bool
+     */
+    public function canMapNameToType(string $typeName): bool;
+
+    /**
+     * Returns a GraphQL type by name (can be either an input or output type)
+     *
+     * @param string $typeName The name of the GraphQL type
+     * @return Type&(InputType|OutputType)
+     */
+    public function mapNameToType(string $typeName): Type;
 }

--- a/src/Mappers/StaticTypeMapper.php
+++ b/src/Mappers/StaticTypeMapper.php
@@ -131,4 +131,25 @@ final class StaticTypeMapper implements TypeMapperInterface
         }
         throw CannotMapTypeException::createForName($typeName);
     }
+
+    /**
+     * Returns true if this type mapper can map the $typeName GraphQL name to a GraphQL type.
+     *
+     * @param string $typeName The name of the GraphQL type
+     * @return bool
+     */
+    public function canMapNameToType(string $typeName): bool
+    {
+        foreach ($this->types as $type) {
+            if ($type->name === $typeName) {
+                return true;
+            }
+        }
+        foreach ($this->inputTypes as $inputType) {
+            if ($inputType->name === $typeName) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/Mappers/StaticTypeMapper.php
+++ b/src/Mappers/StaticTypeMapper.php
@@ -32,14 +32,14 @@ final class StaticTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @var array<string,InputType>
+     * @var array<string,InputType&Type>
      */
     private $inputTypes;
 
     /**
      * An array mapping a fully qualified class name to the matching InputTypeInterface
      *
-     * @param array<string,InputType> $inputTypes
+     * @param array<string,InputType&Type> $inputTypes
      */
     public function setInputTypes(array $inputTypes): void
     {

--- a/src/Mappers/StaticTypeMapper.php
+++ b/src/Mappers/StaticTypeMapper.php
@@ -6,6 +6,7 @@ use function array_keys;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\Type;
 use TheCodingMachine\GraphQL\Controllers\Mappers\Interfaces\InterfacesResolverInterface;
 
 /**
@@ -106,5 +107,28 @@ final class StaticTypeMapper implements TypeMapperInterface
             return $this->inputTypes[$className];
         }
         throw CannotMapTypeException::createForInputType($className);
+    }
+
+    /**
+     * Returns a GraphQL type by name (can be either an input or output type)
+     *
+     * @param string $typeName The name of the GraphQL type
+     * @param RecursiveTypeMapperInterface $recursiveTypeMapper
+     * @return Type&(InputType|OutputType)
+     * @throws CannotMapTypeException
+     */
+    public function mapNameToType(string $typeName, RecursiveTypeMapperInterface $recursiveTypeMapper): Type
+    {
+        foreach ($this->types as $type) {
+            if ($type->name === $typeName) {
+                return $type;
+            }
+        }
+        foreach ($this->inputTypes as $inputType) {
+            if ($inputType->name === $typeName) {
+                return $inputType;
+            }
+        }
+        throw CannotMapTypeException::createForName($typeName);
     }
 }

--- a/src/Mappers/TypeMapperInterface.php
+++ b/src/Mappers/TypeMapperInterface.php
@@ -33,6 +33,15 @@ interface TypeMapperInterface
     public function mapClassToType(string $className, RecursiveTypeMapperInterface $recursiveTypeMapper): ObjectType;
 
     /**
+     * Returns a GraphQL type by name (can be either an input or output type)
+     *
+     * @param string $typeName The name of the GraphQL type
+     * @param RecursiveTypeMapperInterface $recursiveTypeMapper
+     * @return Type&(InputType|OutputType)
+     */
+    public function mapNameToType(string $typeName, RecursiveTypeMapperInterface $recursiveTypeMapper): Type;
+
+    /**
      * Returns the list of classes that have matching input GraphQL types.
      *
      * @return string[]

--- a/src/Mappers/TypeMapperInterface.php
+++ b/src/Mappers/TypeMapperInterface.php
@@ -33,6 +33,14 @@ interface TypeMapperInterface
     public function mapClassToType(string $className, RecursiveTypeMapperInterface $recursiveTypeMapper): ObjectType;
 
     /**
+     * Returns true if this type mapper can map the $typeName GraphQL name to a GraphQL type.
+     *
+     * @param string $typeName The name of the GraphQL type
+     * @return bool
+     */
+    public function canMapNameToType(string $typeName): bool;
+
+    /**
      * Returns a GraphQL type by name (can be either an input or output type)
      *
      * @param string $typeName The name of the GraphQL type

--- a/src/NamingStrategy.php
+++ b/src/NamingStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+
+class NamingStrategy implements NamingStrategyInterface
+{
+    /**
+     * Returns the name of the GraphQL interface from a name of a concrete class (when the interface is created
+     * automatically to manage inheritance)
+     */
+    public function getInterfaceNameFromConcreteName(string $concreteType): string
+    {
+        return $concreteType.'Interface';
+    }
+}

--- a/src/NamingStrategyInterface.php
+++ b/src/NamingStrategyInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+interface NamingStrategyInterface
+{
+    /**
+     * Returns the name of the GraphQL interface from a name of GraphQL concrete type (when the interface is created
+     * automatically to manage inheritance)
+     */
+    public function getInterfaceNameFromConcreteName(string $concreteType): string;
+}

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -41,12 +41,10 @@ class Schema extends \GraphQL\Type\Schema
             return $recursiveTypeMapper->getOutputTypes();
         });
 
-        /*$config->setTypeLoader(function(string $name) use ($recursiveTypeMapper) {
-            // FIXME: TYPELOADER IS COMPLETELY FALSE.
+        $config->setTypeLoader(function(string $name) use ($recursiveTypeMapper) {
             // We need to find a type FROM a GraphQL type name
-            // Therefore, we need to modify the TypeMapperInterface.
-            return $registry->get($name);
-        });*/
+            return $recursiveTypeMapper->mapNameToType($name);
+        });
 
         parent::__construct($config);
     }

--- a/src/TypeGenerator.php
+++ b/src/TypeGenerator.php
@@ -51,7 +51,7 @@ class TypeGenerator
             throw MissingAnnotationException::missingTypeException();
         }
 
-        $typeName = $this->getName($refTypeClass, $typeField);
+        $typeName = $this->getName($refTypeClass->getName(), $typeField);
 
         if (!isset($this->cache[$typeName])) {
             $this->cache[$typeName] = new ObjectType([
@@ -81,10 +81,13 @@ class TypeGenerator
         return $this->cache[$typeName];
     }
 
-    private function getName(ReflectionClass $refTypeClass, Type $type): string
+    /**
+     * @param string $className The type class name
+     * @param Type $type
+     * @return string
+     */
+    public function getName(string $className, Type $type): string
     {
-        $className = $refTypeClass->getName();
-
         if ($prevPos = strrpos($className, '\\')) {
             $className = substr($className, $prevPos + 1);
         }

--- a/src/Types/InterfaceFromObjectType.php
+++ b/src/Types/InterfaceFromObjectType.php
@@ -11,13 +11,12 @@ use TheCodingMachine\GraphQL\Controllers\Mappers\RecursiveTypeMapperInterface;
 class InterfaceFromObjectType extends \GraphQL\Type\Definition\InterfaceType
 {
     /**
+     * @param string $name The name of the interface
      * @param ObjectType $type
      * @param RecursiveTypeMapperInterface $typeMapper
      */
-    public function __construct(ObjectType $type, RecursiveTypeMapperInterface $typeMapper)
+    public function __construct(string $name, ObjectType $type, RecursiveTypeMapperInterface $typeMapper)
     {
-        $name = $type->name.'Interface';
-
         parent::__construct([
             'name' => $name,
             'fields' => function() use ($type) {

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -166,7 +166,18 @@ abstract class AbstractQueryProviderTest extends TestCase
                             throw CannotMapTypeException::createForName($typeName);
                     }
                 }
-            });
+
+                /**
+                 * Returns true if this type mapper can map the $typeName GraphQL name to a GraphQL type.
+                 *
+                 * @param string $typeName The name of the GraphQL type
+                 * @return bool
+                 */
+                public function canMapNameToType(string $typeName): bool
+                {
+                    return $typeName === 'TestObject' || $typeName === 'TestObject2';
+                }
+            }, new NamingStrategy(), new ArrayCache());
         }
         return $this->typeMapper;
     }

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -147,6 +147,25 @@ abstract class AbstractQueryProviderTest extends TestCase
                 {
                     return [TestObject::class, TestObject2::class];
                 }
+
+                /**
+                 * Returns a GraphQL type by name (can be either an input or output type)
+                 *
+                 * @param string $typeName The name of the GraphQL type
+                 * @return Type&(InputType|OutputType)
+                 * @throws CannotMapTypeException
+                 */
+                public function mapNameToType(string $typeName, RecursiveTypeMapperInterface $recursiveTypeMapper): Type
+                {
+                    switch ($typeName) {
+                        case 'TestObject':
+                            return $this->testObjectType;
+                        case 'TestObject2':
+                            return $this->testObjectType2;
+                        default:
+                            throw CannotMapTypeException::createForName($typeName);
+                    }
+                }
             });
         }
         return $this->typeMapper;

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -5,6 +5,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Integration;
 use function class_exists;
 use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
 use Exception;
+use GraphQL\Error\Debug;
 use GraphQL\GraphQL;
 use GraphQL\Type\Definition\InputType;
 use Mouf\Picotainer\Picotainer;
@@ -25,6 +26,7 @@ use TheCodingMachine\GraphQL\Controllers\Mappers\GlobTypeMapper;
 use TheCodingMachine\GraphQL\Controllers\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQL\Controllers\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQL\Controllers\Mappers\TypeMapperInterface;
+use TheCodingMachine\GraphQL\Controllers\NamingStrategy;
 use TheCodingMachine\GraphQL\Controllers\QueryProviderInterface;
 use TheCodingMachine\GraphQL\Controllers\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQL\Controllers\Containers\EmptyContainer;
@@ -35,6 +37,7 @@ use TheCodingMachine\GraphQL\Controllers\Security\AuthorizationServiceInterface;
 use TheCodingMachine\GraphQL\Controllers\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQL\Controllers\Security\VoidAuthorizationService;
 use TheCodingMachine\GraphQL\Controllers\TypeGenerator;
+use function var_dump;
 
 class EndToEndTest extends TestCase
 {
@@ -73,7 +76,7 @@ class EndToEndTest extends TestCase
                 return new VoidAuthenticationService();
             },
             RecursiveTypeMapperInterface::class => function(ContainerInterface $container) {
-                return new RecursiveTypeMapper($container->get(TypeMapperInterface::class));
+                return new RecursiveTypeMapper($container->get(TypeMapperInterface::class), new NamingStrategy(), new ArrayCache());
             },
             TypeMapperInterface::class => function(ContainerInterface $container) {
                 return new GlobTypeMapper('TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\Integration\\Types',
@@ -140,7 +143,7 @@ class EndToEndTest extends TestCase
                 ]
 
             ]
-        ], $result->toArray()['data']);
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
     }
 
 }

--- a/tests/Mappers/CompositeTypeMapperTest.php
+++ b/tests/Mappers/CompositeTypeMapperTest.php
@@ -69,6 +69,28 @@ class CompositeTypeMapperTest extends AbstractQueryProviderTest
             {
                 return [TestObject::class];
             }
+
+            /**
+             * Returns a GraphQL type by name (can be either an input or output type)
+             *
+             * @param string $typeName The name of the GraphQL type
+             * @param RecursiveTypeMapperInterface $recursiveTypeMapper
+             * @return Type&(InputType|OutputType)
+             */
+            public function mapNameToType(string $typeName, RecursiveTypeMapperInterface $recursiveTypeMapper): Type
+            {
+                switch ($typeName) {
+                    case 'TestObject':
+                        return new ObjectType([
+                            'name'    => 'TestObject',
+                            'fields'  => [
+                                'test'   => Type::string(),
+                            ],
+                        ]);
+                    default:
+                        throw CannotMapTypeException::createForName($typeName);
+                }
+            }
         };
 
         $this->composite = new CompositeTypeMapper([$typeMapper1]);

--- a/tests/Mappers/CompositeTypeMapperTest.php
+++ b/tests/Mappers/CompositeTypeMapperTest.php
@@ -133,4 +133,10 @@ class CompositeTypeMapperTest extends AbstractQueryProviderTest
         $this->expectException(CannotMapTypeException::class);
         $this->composite->mapClassToInputType(\Exception::class);
     }
+
+    public function testException3(): void
+    {
+        $this->expectException(CannotMapTypeException::class);
+        $this->composite->mapNameToType('NotExists', $this->getTypeMapper());
+    }
 }

--- a/tests/Mappers/CompositeTypeMapperTest.php
+++ b/tests/Mappers/CompositeTypeMapperTest.php
@@ -91,6 +91,17 @@ class CompositeTypeMapperTest extends AbstractQueryProviderTest
                         throw CannotMapTypeException::createForName($typeName);
                 }
             }
+
+            /**
+             * Returns true if this type mapper can map the $typeName GraphQL name to a GraphQL type.
+             *
+             * @param string $typeName The name of the GraphQL type
+             * @return bool
+             */
+            public function canMapNameToType(string $typeName): bool
+            {
+                return $typeName === 'TestObject';
+            }
         };
 
         $this->composite = new CompositeTypeMapper([$typeMapper1]);
@@ -106,6 +117,9 @@ class CompositeTypeMapperTest extends AbstractQueryProviderTest
         $this->assertInstanceOf(ObjectType::class, $this->composite->mapClassToType(TestObject::class, $this->getTypeMapper()));
         $this->assertInstanceOf(InputObjectType::class, $this->composite->mapClassToInputType(TestObject::class));
         $this->assertSame([TestObject::class], $this->composite->getSupportedClasses());
+        $this->assertInstanceOf(ObjectType::class, $this->composite->mapNameToType('TestObject', $this->getTypeMapper()));
+        $this->assertTrue($this->composite->canMapNameToType('TestObject'));
+        $this->assertFalse($this->composite->canMapNameToType('NotExists'));
     }
 
     public function testException1(): void

--- a/tests/Mappers/GlobTypeMapperTest.php
+++ b/tests/Mappers/GlobTypeMapperTest.php
@@ -32,6 +32,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
         $this->assertInstanceOf(ObjectType::class, $mapper->mapClassToType(TestObject::class, $this->getTypeMapper()));
         $this->assertInstanceOf(ObjectType::class, $mapper->mapNameToType('Foo', $this->getTypeMapper()));
         $this->assertTrue($mapper->canMapNameToType('Foo'));
+        $this->assertFalse($mapper->canMapNameToType('NotExists'));
 
         $this->expectException(CannotMapTypeException::class);
         $mapper->mapClassToType(\stdClass::class, $this->getTypeMapper());
@@ -68,6 +69,22 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
         $this->expectException(ClassNotFoundException::class);
         $this->expectExceptionMessage("Could not autoload class 'Foobar' defined in @Type annotation of class 'TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\BadClassType\\TestType'");
         $mapper->canMapClassToType(TestType::class);
+    }
+
+    public function testGlobTypeMapperNameNotFoundException()
+    {
+        $container = new Picotainer([
+            FooType::class => function() {
+                return new FooType();
+            }
+        ]);
+
+        $typeGenerator = $this->getTypeGenerator();
+
+        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NullCache());
+
+        $this->expectException(CannotMapTypeException::class);
+        $mapper->mapNameToType('NotExists', $this->getTypeMapper());
     }
 
     public function testGlobTypeMapperInputType()

--- a/tests/Mappers/GlobTypeMapperTest.php
+++ b/tests/Mappers/GlobTypeMapperTest.php
@@ -4,6 +4,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Mappers;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Mouf\Picotainer\Picotainer;
+use Symfony\Component\Cache\Simple\ArrayCache;
 use Symfony\Component\Cache\Simple\NullCache;
 use TheCodingMachine\GraphQL\Controllers\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Exceptions\ClassNotFoundException;
@@ -25,7 +26,9 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
 
         $typeGenerator = $this->getTypeGenerator();
 
-        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NullCache());
+        $cache = new ArrayCache();
+
+        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), $cache);
 
         $this->assertSame([TestObject::class], $mapper->getSupportedClasses());
         $this->assertTrue($mapper->canMapClassToType(TestObject::class));
@@ -33,6 +36,10 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
         $this->assertInstanceOf(ObjectType::class, $mapper->mapNameToType('Foo', $this->getTypeMapper()));
         $this->assertTrue($mapper->canMapNameToType('Foo'));
         $this->assertFalse($mapper->canMapNameToType('NotExists'));
+
+        $anotherMapperSameCache = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), $cache);
+        $this->assertTrue($anotherMapperSameCache->canMapClassToType(TestObject::class));
+        $this->assertTrue($anotherMapperSameCache->canMapNameToType('Foo'));
 
         $this->expectException(CannotMapTypeException::class);
         $mapper->mapClassToType(\stdClass::class, $this->getTypeMapper());

--- a/tests/Mappers/GlobTypeMapperTest.php
+++ b/tests/Mappers/GlobTypeMapperTest.php
@@ -31,6 +31,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
         $this->assertTrue($mapper->canMapClassToType(TestObject::class));
         $this->assertInstanceOf(ObjectType::class, $mapper->mapClassToType(TestObject::class, $this->getTypeMapper()));
         $this->assertInstanceOf(ObjectType::class, $mapper->mapNameToType('Foo', $this->getTypeMapper()));
+        $this->assertTrue($mapper->canMapNameToType('Foo'));
 
         $this->expectException(CannotMapTypeException::class);
         $mapper->mapClassToType(\stdClass::class, $this->getTypeMapper());

--- a/tests/Mappers/GlobTypeMapperTest.php
+++ b/tests/Mappers/GlobTypeMapperTest.php
@@ -27,9 +27,10 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
 
         $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NullCache());
 
+        $this->assertSame([TestObject::class], $mapper->getSupportedClasses());
         $this->assertTrue($mapper->canMapClassToType(TestObject::class));
         $this->assertInstanceOf(ObjectType::class, $mapper->mapClassToType(TestObject::class, $this->getTypeMapper()));
-        $this->assertSame([TestObject::class], $mapper->getSupportedClasses());
+        $this->assertInstanceOf(ObjectType::class, $mapper->mapNameToType('Foo', $this->getTypeMapper()));
 
         $this->expectException(CannotMapTypeException::class);
         $mapper->mapClassToType(\stdClass::class, $this->getTypeMapper());

--- a/tests/Mappers/RecursiveTypeMapperTest.php
+++ b/tests/Mappers/RecursiveTypeMapperTest.php
@@ -68,8 +68,12 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
         $this->assertTrue($recursiveMapper->canMapNameToType('ClassA'));
         $this->assertTrue($recursiveMapper->canMapNameToType('ClassB'));
         $this->assertTrue($recursiveMapper->canMapNameToType('ClassAInterface'));
+        $this->assertFalse($recursiveMapper->canMapNameToType('NotExists'));
         $this->assertSame('ClassA', $recursiveMapper->mapNameToType('ClassA')->name);
         $this->assertSame('ClassAInterface', $recursiveMapper->mapNameToType('ClassAInterface')->name);
+
+        $this->expectException(CannotMapTypeException::class);
+        $recursiveMapper->mapNameToType('NotExists');
     }
 
 
@@ -137,4 +141,16 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
         $this->expectException(CannotMapTypeException::class);
         $recursiveMapper->mapClassToInterfaceOrType('Not exists');
     }
+
+    public function testGetOutputTypes()
+    {
+        $recursiveMapper = $this->getTypeMapper();
+
+        $outputTypes = $recursiveMapper->getOutputTypes();
+        $this->assertArrayHasKey('TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\Interfaces\\ClassA', $outputTypes);
+        $this->assertArrayHasKey('TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\Interfaces\\ClassB', $outputTypes);
+        $this->assertArrayNotHasKey('TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\Interfaces\\ClassC', $outputTypes);
+    }
+
+
 }

--- a/tests/Mappers/RecursiveTypeMapperTest.php
+++ b/tests/Mappers/RecursiveTypeMapperTest.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use Mouf\Picotainer\Picotainer;
+use Symfony\Component\Cache\Simple\ArrayCache;
 use Symfony\Component\Cache\Simple\NullCache;
 use TheCodingMachine\GraphQL\Controllers\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\Interfaces\ClassA;
@@ -15,6 +16,7 @@ use TheCodingMachine\GraphQL\Controllers\Fixtures\Interfaces\ClassC;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\Interfaces\Types\ClassAType;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\Interfaces\Types\ClassBType;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\TestObject;
+use TheCodingMachine\GraphQL\Controllers\NamingStrategy;
 use TheCodingMachine\GraphQL\Controllers\TypeGenerator;
 
 class RecursiveTypeMapperTest extends AbstractQueryProviderTest
@@ -31,7 +33,7 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
             ClassB::class => $objectType
         ]);
 
-        $recursiveTypeMapper = new RecursiveTypeMapper($typeMapper);
+        $recursiveTypeMapper = new RecursiveTypeMapper($typeMapper, new NamingStrategy(), new ArrayCache());
 
         $this->assertFalse($typeMapper->canMapClassToType(ClassC::class));
         $this->assertTrue($recursiveTypeMapper->canMapClassToType(ClassC::class));
@@ -41,6 +43,35 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
         $this->expectException(CannotMapTypeException::class);
         $recursiveTypeMapper->mapClassToType(ClassA::class);
     }
+
+    public function testMapNameToType()
+    {
+        $objectType = new ObjectType([
+            'name' => 'Foobar'
+        ]);
+
+        $typeMapper = new StaticTypeMapper();
+        $typeMapper->setTypes([
+            ClassB::class => $objectType
+        ]);
+
+        $recursiveTypeMapper = new RecursiveTypeMapper($typeMapper, new NamingStrategy(), new ArrayCache());
+
+        $this->assertTrue($recursiveTypeMapper->canMapNameToType('Foobar'));
+        $this->assertSame($objectType, $recursiveTypeMapper->mapNameToType('Foobar'));
+    }
+
+    public function testMapNameToType2()
+    {
+        $recursiveMapper = $this->getTypeMapper();
+
+        $this->assertTrue($recursiveMapper->canMapNameToType('ClassA'));
+        $this->assertTrue($recursiveMapper->canMapNameToType('ClassB'));
+        $this->assertTrue($recursiveMapper->canMapNameToType('ClassAInterface'));
+        $this->assertSame('ClassA', $recursiveMapper->mapNameToType('ClassA')->name);
+        $this->assertSame('ClassAInterface', $recursiveMapper->mapNameToType('ClassAInterface')->name);
+    }
+
 
     public function testMapClassToInputType()
     {
@@ -53,7 +84,7 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
             ClassB::class => $inputObjectType
         ]);
 
-        $recursiveTypeMapper = new RecursiveTypeMapper($typeMapper);
+        $recursiveTypeMapper = new RecursiveTypeMapper($typeMapper, new NamingStrategy(), new ArrayCache());
 
         $this->assertFalse($recursiveTypeMapper->canMapClassToInputType(ClassC::class));
 
@@ -76,7 +107,7 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
 
         $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Interfaces\Types', $typeGenerator, $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NullCache());
 
-        return new RecursiveTypeMapper($mapper);
+        return new RecursiveTypeMapper($mapper, new NamingStrategy(), new ArrayCache());
     }
 
     public function testMapClassToInterfaceOrType()

--- a/tests/Mappers/StaticTypeMapperTest.php
+++ b/tests/Mappers/StaticTypeMapperTest.php
@@ -30,7 +30,7 @@ class StaticTypeMapperTest extends AbstractQueryProviderTest
         ]);
         $this->typeMapper->setInputTypes([
             TestObject::class => new InputObjectType([
-                'name'    => 'TestObject',
+                'name'    => 'TestInputObject',
                 'fields'  => [
                     'test'   => Type::string(),
                 ],
@@ -47,6 +47,8 @@ class StaticTypeMapperTest extends AbstractQueryProviderTest
         $this->assertInstanceOf(ObjectType::class, $this->typeMapper->mapClassToType(TestObject::class, $this->getTypeMapper()));
         $this->assertInstanceOf(InputObjectType::class, $this->typeMapper->mapClassToInputType(TestObject::class));
         $this->assertSame([TestObject::class], $this->typeMapper->getSupportedClasses());
+        $this->assertSame('TestObject', $this->typeMapper->mapNameToType('TestObject', $this->getTypeMapper())->name);
+        $this->assertSame('TestInputObject', $this->typeMapper->mapNameToType('TestInputObject', $this->getTypeMapper())->name);
     }
 
     public function testException1(): void
@@ -59,5 +61,11 @@ class StaticTypeMapperTest extends AbstractQueryProviderTest
     {
         $this->expectException(CannotMapTypeException::class);
         $this->typeMapper->mapClassToInputType(\Exception::class);
+    }
+
+    public function testException3(): void
+    {
+        $this->expectException(CannotMapTypeException::class);
+        $this->typeMapper->mapNameToType('notExists', $this->getTypeMapper());
     }
 }

--- a/tests/Mappers/StaticTypeMapperTest.php
+++ b/tests/Mappers/StaticTypeMapperTest.php
@@ -49,6 +49,9 @@ class StaticTypeMapperTest extends AbstractQueryProviderTest
         $this->assertSame([TestObject::class], $this->typeMapper->getSupportedClasses());
         $this->assertSame('TestObject', $this->typeMapper->mapNameToType('TestObject', $this->getTypeMapper())->name);
         $this->assertSame('TestInputObject', $this->typeMapper->mapNameToType('TestInputObject', $this->getTypeMapper())->name);
+        $this->assertTrue($this->typeMapper->canMapNameToType('TestObject'));
+        $this->assertTrue($this->typeMapper->canMapNameToType('TestInputObject'));
+        $this->assertFalse($this->typeMapper->canMapNameToType('NotExists'));
     }
 
     public function testException1(): void


### PR DESCRIPTION
In order to improve performance, we need to add a TypeLoader to the schema.
The TypeLoader is in charge of loading types by GraphQL name.
We therefore need to add a new method to the TypeMapperInterface.