### PR TITLE
Splitting InputTypeGenerator in 2

### DIFF
--- a/src/InputTypeUtils.php
+++ b/src/InputTypeUtils.php
@@ -1,0 +1,66 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types\Object_;
+use ReflectionMethod;
+
+class InputTypeUtils
+{
+    /**
+     * @var AnnotationReader
+     */
+    private $annotationReader;
+    /**
+     * @var NamingStrategyInterface
+     */
+    private $namingStrategy;
+
+    public function __construct(AnnotationReader $annotationReader,
+                                NamingStrategyInterface $namingStrategy)
+    {
+        $this->annotationReader = $annotationReader;
+        $this->namingStrategy = $namingStrategy;
+    }
+
+    /**
+     * Returns an array with 2 elements: [ $inputName, $className ]
+     *
+     * @param ReflectionMethod $method
+     * @return string[]
+     */
+    public function getInputTypeNameAndClassName(ReflectionMethod $method): array
+    {
+        $fqsen = ltrim((string) $this->validateReturnType($method), '\\');
+        $factory = $this->annotationReader->getFactoryAnnotation($method);
+        if ($factory === null) {
+            throw new \RuntimeException($method->getDeclaringClass()->getName().'::'.$method->getName().' has no @Factory annotation.');
+        }
+        return [$this->namingStrategy->getInputTypeName($fqsen, $factory), $fqsen];
+    }
+
+    private function validateReturnType(ReflectionMethod $refMethod): Fqsen
+    {
+        $returnType = $refMethod->getReturnType();
+        if ($returnType === null) {
+            throw MissingTypeHintException::missingReturnType($refMethod);
+        }
+
+        if ($returnType->allowsNull()) {
+            throw MissingTypeHintException::nullableReturnType($refMethod);
+        }
+
+        $type = (string) $returnType;
+
+        $typeResolver = new \phpDocumentor\Reflection\TypeResolver();
+
+        $phpdocType = $typeResolver->resolve($type);
+        if (!$phpdocType instanceof Object_) {
+            throw MissingTypeHintException::invalidReturnType($refMethod);
+        }
+
+        return $phpdocType->getFqsen();
+    }
+}

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -18,6 +18,7 @@ use TheCodingMachine\GraphQL\Controllers\AnnotationReader;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Factory;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Type;
 use TheCodingMachine\GraphQL\Controllers\InputTypeGenerator;
+use TheCodingMachine\GraphQL\Controllers\InputTypeUtils;
 use TheCodingMachine\GraphQL\Controllers\NamingStrategy;
 use TheCodingMachine\GraphQL\Controllers\TypeGenerator;
 
@@ -85,11 +86,15 @@ final class GlobTypeMapper implements TypeMapperInterface
      * @var InputTypeGenerator
      */
     private $inputTypeGenerator;
+    /**
+     * @var InputTypeUtils
+     */
+    private $inputTypeUtils;
 
     /**
      * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
      */
-    public function __construct(string $namespace, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategy $namingStrategy, CacheInterface $cache, ?int $globTtl = 2, ?int $mapTtl = null)
+    public function __construct(string $namespace, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategy $namingStrategy, CacheInterface $cache, ?int $globTtl = 2, ?int $mapTtl = null)
     {
         $this->namespace = $namespace;
         $this->typeGenerator = $typeGenerator;
@@ -100,6 +105,7 @@ final class GlobTypeMapper implements TypeMapperInterface
         $this->globTtl = $globTtl;
         $this->mapTtl = $mapTtl;
         $this->inputTypeGenerator = $inputTypeGenerator;
+        $this->inputTypeUtils = $inputTypeUtils;
     }
 
     /**
@@ -161,7 +167,7 @@ final class GlobTypeMapper implements TypeMapperInterface
             foreach ($refClass->getMethods() as $method) {
                 $factory = $this->annotationReader->getFactoryAnnotation($method);
                 if ($factory !== null) {
-                    [$inputName, $className] = $this->inputTypeGenerator->getInputTypeNameAndClassName($method);
+                    [$inputName, $className] = $this->inputTypeUtils->getInputTypeNameAndClassName($method);
 
                     if (isset($this->mapClassToFactory[$className])) {
                         throw DuplicateMappingException::createForFactory($className, $this->mapClassToFactory[$className][0], $this->mapClassToFactory[$className][1], $refClass->getName(), $method->name);

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -42,6 +42,7 @@ abstract class AbstractQueryProviderTest extends TestCase
     private $registry;
     private $typeGenerator;
     private $inputTypeGenerator;
+    private $inputTypeUtils;
     private $controllerQueryProviderFactory;
     private $annotationReader;
 
@@ -270,9 +271,17 @@ abstract class AbstractQueryProviderTest extends TestCase
     protected function getInputTypeGenerator(): InputTypeGenerator
     {
         if ($this->inputTypeGenerator === null) {
-            $this->inputTypeGenerator = new InputTypeGenerator($this->getAnnotationReader(), $this->getControllerQueryProviderFactory(), new NamingStrategy(), $this->getHydrator());
+            $this->inputTypeGenerator = new InputTypeGenerator($this->getInputTypeUtils(), $this->getControllerQueryProviderFactory(), $this->getHydrator());
         }
         return $this->inputTypeGenerator;
+    }
+
+    protected function getInputTypeUtils(): InputTypeUtils
+    {
+        if ($this->inputTypeUtils === null) {
+            $this->inputTypeUtils = new InputTypeUtils($this->getAnnotationReader(), new NamingStrategy());
+        }
+        return $this->inputTypeUtils;
     }
 
     protected function getControllerQueryProviderFactory(): ControllerQueryProviderFactory

--- a/tests/InputTypeUtilsTest.php
+++ b/tests/InputTypeUtilsTest.php
@@ -5,33 +5,33 @@ namespace TheCodingMachine\GraphQL\Controllers;
 use ReflectionMethod;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\TestObject;
 
-class InputTypeGeneratorTest extends AbstractQueryProviderTest
+class InputTypeUtilsTest extends AbstractQueryProviderTest
 {
 
     public function testNoReturnType()
     {
-        $inputTypeGenerator = $this->getInputTypeGenerator();
+        $inputTypeGenerator = $this->getInputTypeUtils();
 
         $this->expectException(MissingTypeHintException::class);
-        $this->expectExceptionMessage('Factory "TheCodingMachine\\GraphQL\\Controllers\\InputTypeGeneratorTest::factoryNoReturnType" must have a return type.');
+        $this->expectExceptionMessage('Factory "TheCodingMachine\\GraphQL\\Controllers\\InputTypeUtilsTest::factoryNoReturnType" must have a return type.');
         $inputTypeGenerator->getInputTypeNameAndClassName(new ReflectionMethod($this, 'factoryNoReturnType'));
     }
 
     public function testInvalidReturnType()
     {
-        $inputTypeGenerator = $this->getInputTypeGenerator();
+        $inputTypeGenerator = $this->getInputTypeUtils();
 
         $this->expectException(MissingTypeHintException::class);
-        $this->expectExceptionMessage('The return type of factory "TheCodingMachine\\GraphQL\\Controllers\\InputTypeGeneratorTest::factoryStringReturnType" must be an object, "string" passed instead.');
+        $this->expectExceptionMessage('The return type of factory "TheCodingMachine\\GraphQL\\Controllers\\InputTypeUtilsTest::factoryStringReturnType" must be an object, "string" passed instead.');
         $inputTypeGenerator->getInputTypeNameAndClassName(new ReflectionMethod($this, 'factoryStringReturnType'));
     }
 
     public function testNullableReturnType()
     {
-        $inputTypeGenerator = $this->getInputTypeGenerator();
+        $inputTypeGenerator = $this->getInputTypeUtils();
 
         $this->expectException(MissingTypeHintException::class);
-        $this->expectExceptionMessage('Factory "TheCodingMachine\\GraphQL\\Controllers\\InputTypeGeneratorTest::factoryNullableReturnType" must have a non nullable return type.');
+        $this->expectExceptionMessage('Factory "TheCodingMachine\\GraphQL\\Controllers\\InputTypeUtilsTest::factoryNullableReturnType" must have a non nullable return type.');
         $inputTypeGenerator->getInputTypeNameAndClassName(new ReflectionMethod($this, 'factoryNullableReturnType'));
     }
 

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -23,6 +23,7 @@ use TheCodingMachine\GraphQL\Controllers\GlobControllerQueryProvider;
 use TheCodingMachine\GraphQL\Controllers\Hydrators\HydratorInterface;
 use TheCodingMachine\GraphQL\Controllers\Hydrators\FactoryHydrator;
 use TheCodingMachine\GraphQL\Controllers\InputTypeGenerator;
+use TheCodingMachine\GraphQL\Controllers\InputTypeUtils;
 use TheCodingMachine\GraphQL\Controllers\Mappers\GlobTypeMapper;
 use TheCodingMachine\GraphQL\Controllers\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQL\Controllers\Mappers\RecursiveTypeMapperInterface;
@@ -83,6 +84,7 @@ class EndToEndTest extends TestCase
                 return new GlobTypeMapper('TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\Integration\\Types',
                     $container->get(TypeGenerator::class),
                     $container->get(InputTypeGenerator::class),
+                    $container->get(InputTypeUtils::class),
                     $container->get(BasicAutoWiringContainer::class),
                     $container->get(AnnotationReader::class),
                     $container->get(NamingStrategyInterface::class),
@@ -98,10 +100,15 @@ class EndToEndTest extends TestCase
             },
             InputTypeGenerator::class => function(ContainerInterface $container) {
                 return new InputTypeGenerator(
-                    $container->get(AnnotationReader::class),
+                    $container->get(InputTypeUtils::class),
                     $container->get(ControllerQueryProviderFactory::class),
-                    $container->get(NamingStrategyInterface::class),
                     $container->get(HydratorInterface::class)
+                );
+            },
+            InputTypeUtils::class => function(ContainerInterface $container) {
+                return new InputTypeUtils(
+                    $container->get(AnnotationReader::class),
+                    $container->get(NamingStrategyInterface::class)
                 );
             },
             AnnotationReader::class => function(ContainerInterface $container) {

--- a/tests/Mappers/GlobTypeMapperTest.php
+++ b/tests/Mappers/GlobTypeMapperTest.php
@@ -32,7 +32,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
 
         $cache = new ArrayCache();
 
-        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $inputTypeGenerator, $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $cache);
+        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $inputTypeGenerator, $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $cache);
 
         $this->assertSame([TestObject::class], $mapper->getSupportedClasses());
         $this->assertTrue($mapper->canMapClassToType(TestObject::class));
@@ -42,7 +42,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
         $this->assertFalse($mapper->canMapNameToType('NotExists'));
 
         // Again to test cache
-        $anotherMapperSameCache = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $this->getInputTypeGenerator(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $cache);
+        $anotherMapperSameCache = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $this->getInputTypeGenerator(), $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $cache);
         $this->assertTrue($anotherMapperSameCache->canMapClassToType(TestObject::class));
         $this->assertTrue($anotherMapperSameCache->canMapNameToType('Foo'));
 
@@ -60,7 +60,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
 
         $typeGenerator = $this->getTypeGenerator();
 
-        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\DuplicateTypes', $typeGenerator, $this->getInputTypeGenerator(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), new NullCache());
+        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\DuplicateTypes', $typeGenerator, $this->getInputTypeGenerator(), $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), new NullCache());
 
         $this->expectException(DuplicateMappingException::class);
         $mapper->canMapClassToType(TestType::class);
@@ -76,7 +76,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
 
         $typeGenerator = $this->getTypeGenerator();
 
-        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\DuplicateInputTypes', $typeGenerator, $this->getInputTypeGenerator(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), new NullCache());
+        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\DuplicateInputTypes', $typeGenerator, $this->getInputTypeGenerator(), $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), new NullCache());
 
         $this->expectException(DuplicateMappingException::class);
         $this->expectExceptionMessage('The class \'TheCodingMachine\GraphQL\Controllers\Fixtures\TestObject\' should be mapped to only one GraphQL Input type. Two methods are pointing via the @Factory annotation to this class: \'TheCodingMachine\GraphQL\Controllers\Fixtures\DuplicateInputTypes\TestFactory::myFactory\' and \'TheCodingMachine\GraphQL\Controllers\Fixtures\DuplicateInputTypes\TestFactory2::myFactory\'');
@@ -93,7 +93,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
 
         $typeGenerator = $this->getTypeGenerator();
 
-        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\BadClassType', $typeGenerator, $this->getInputTypeGenerator(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), new NullCache());
+        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\BadClassType', $typeGenerator, $this->getInputTypeGenerator(), $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), new NullCache());
 
         $this->expectException(ClassNotFoundException::class);
         $this->expectExceptionMessage("Could not autoload class 'Foobar' defined in @Type annotation of class 'TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\BadClassType\\TestType'");
@@ -110,7 +110,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
 
         $typeGenerator = $this->getTypeGenerator();
 
-        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $this->getInputTypeGenerator(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), new NullCache());
+        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $this->getInputTypeGenerator(), $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), new NullCache());
 
         $this->expectException(CannotMapTypeException::class);
         $mapper->mapNameToType('NotExists', $this->getTypeMapper());
@@ -131,7 +131,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
 
         $cache = new ArrayCache();
 
-        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $this->getInputTypeGenerator(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $cache);
+        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $this->getInputTypeGenerator(), $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $cache);
 
         $this->assertTrue($mapper->canMapClassToInputType(TestObject::class));
 
@@ -140,7 +140,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
         $this->assertSame('TestObjectInput', $inputType->name);
 
         // Again to test cache
-        $anotherMapperSameCache = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $this->getInputTypeGenerator(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $cache);
+        $anotherMapperSameCache = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Types', $typeGenerator, $this->getInputTypeGenerator(), $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $cache);
 
         $this->assertTrue($anotherMapperSameCache->canMapClassToInputType(TestObject::class));
         $this->assertSame('TestObjectInput', $anotherMapperSameCache->mapClassToInputType(TestObject::class, $this->getTypeMapper())->name);

--- a/tests/Mappers/RecursiveTypeMapperTest.php
+++ b/tests/Mappers/RecursiveTypeMapperTest.php
@@ -111,7 +111,7 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
 
         $typeGenerator = new TypeGenerator($this->getAnnotationReader(), $this->getControllerQueryProviderFactory(), $namingStrategy);
 
-        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Interfaces\Types', $typeGenerator, $this->getInputTypeGenerator(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), $namingStrategy, new NullCache());
+        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQL\Controllers\Fixtures\Interfaces\Types', $typeGenerator, $this->getInputTypeGenerator(), $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQL\Controllers\AnnotationReader(new AnnotationReader()), $namingStrategy, new NullCache());
 
         return new RecursiveTypeMapper($mapper, new NamingStrategy(), new ArrayCache());
     }


### PR DESCRIPTION
Useful for Symfony bundle that needs one part but not the other in the compiler pass.