### PR TITLE
Refactoring returnType into outputType

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ As an alternative, you can also manually specify the GraphqlType of your return 
 
 ```php
 /**
- * @Query(returnType=UserListType::class)
+ * @Query(outputType="UserListType")
  */
 public function users(int $limit, int $offset)
 {
@@ -118,7 +118,7 @@ You can also specify the name of an entry in the container that resolves to the 
 
 ```php
 /**
- * @Query(returnType="userListType")
+ * @Query(outputType="userListType")
  */
 public function users(int $limit, int $offset)
 {
@@ -313,13 +313,13 @@ You simply have to:
 
 Please note that the first argument of the method is the object we are calling the field on. The remaining arguments are converted to GraphQL arguments of the field.
 
-Just like the @Query and @Mutation annotations, the @Field annotation can be passed an optional "name" and "returnType" attribute:
+Just like the @Query and @Mutation annotations, the @Field annotation can be passed an optional "name" and "outputType" attribute:
 
 ```php
 class PostType extends AbstractAnnotatedObjectType
 {
     /**
-     * @Field(name="customField", returnType="myCustomField")
+     * @Field(name="customField", outputType="myCustomField")
      */
     public function getCustomField(Post $source, bool $truncate = false): CustomField
     {

--- a/src/Annotations/AbstractRequest.php
+++ b/src/Annotations/AbstractRequest.php
@@ -9,7 +9,7 @@ abstract class AbstractRequest
     /**
      * @var string|null
      */
-    private $returnType;
+    private $outputType;
 
     /**
      * @var string|null
@@ -21,7 +21,7 @@ abstract class AbstractRequest
      */
     public function __construct(array $attributes = [])
     {
-        $this->returnType = $attributes['returnType'] ?? null;
+        $this->outputType = $attributes['outputType'] ?? null;
         $this->name = $attributes['name'] ?? null;
     }
 
@@ -31,9 +31,9 @@ abstract class AbstractRequest
      *
      * @return string|null
      */
-    public function getReturnType(): ?string
+    public function getOutputType(): ?string
     {
-        return $this->returnType;
+        return $this->outputType;
     }
 
     /**

--- a/src/Annotations/Field.php
+++ b/src/Annotations/Field.php
@@ -7,7 +7,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Annotations;
  * @Annotation
  * @Target({"METHOD"})
  * @Attributes({
- *   @Attribute("returnType", type = "string"),
+ *   @Attribute("outputType", type = "string"),
  * })
  */
 class Field extends AbstractRequest

--- a/src/Annotations/Mutation.php
+++ b/src/Annotations/Mutation.php
@@ -7,7 +7,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Annotations;
  * @Annotation
  * @Target({"METHOD"})
  * @Attributes({
- *   @Attribute("returnType", type = "string"),
+ *   @Attribute("outputType", type = "string"),
  * })
  */
 class Mutation extends AbstractRequest

--- a/src/Annotations/Query.php
+++ b/src/Annotations/Query.php
@@ -7,7 +7,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Annotations;
  * @Annotation
  * @Target({"METHOD"})
  * @Attributes({
- *   @Attribute("returnType", type = "string"),
+ *   @Attribute("outputType", type = "string"),
  * })
  */
 class Query extends AbstractRequest

--- a/src/Annotations/SourceField.php
+++ b/src/Annotations/SourceField.php
@@ -12,7 +12,7 @@ namespace TheCodingMachine\GraphQL\Controllers\Annotations;
  *   @Attribute("name", type = "string"),
  *   @Attribute("logged", type = "bool"),
  *   @Attribute("right", type = "TheCodingMachine\GraphQL\Controllers\Annotations\Right"),
- *   @Attribute("returnType", type = "string"),
+ *   @Attribute("outputType", type = "string"),
  *   @Attribute("isId", type = "bool"),
  * })
  */
@@ -36,7 +36,7 @@ class SourceField implements SourceFieldInterface
     /**
      * @var string|null
      */
-    private $returnType;
+    private $outputType;
 
     /**
      * @var bool
@@ -51,7 +51,7 @@ class SourceField implements SourceFieldInterface
         $this->name = $attributes['name'] ?? null;
         $this->logged = $attributes['logged'] ?? false;
         $this->right = $attributes['right'] ?? null;
-        $this->returnType = $attributes['returnType'] ?? null;
+        $this->outputType = $attributes['outputType'] ?? null;
         $this->id = $attributes['isId'] ?? false;
     }
 
@@ -90,9 +90,9 @@ class SourceField implements SourceFieldInterface
      *
      * @return string|null
      */
-    public function getReturnType(): ?string
+    public function getOutputType(): ?string
     {
-        return $this->returnType;
+        return $this->outputType;
     }
 
     /**

--- a/src/Annotations/SourceFieldInterface.php
+++ b/src/Annotations/SourceFieldInterface.php
@@ -34,7 +34,7 @@ interface SourceFieldInterface
      *
      * @return string|null
      */
-    public function getReturnType(): ?string;
+    public function getOutputType(): ?string;
 
     /**
      * If the GraphQL type is "ID", isID will return true.

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -10,12 +10,12 @@ use GraphQL\Upload\UploadType;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Types\Nullable;
 use phpDocumentor\Reflection\Types\Self_;
-use Psr\Container\ContainerInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use ReflectionMethod;
 use TheCodingMachine\GraphQL\Controllers\Hydrators\HydratorInterface;
 use TheCodingMachine\GraphQL\Controllers\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQL\Controllers\Types\CustomTypesRegistry;
+use TheCodingMachine\GraphQL\Controllers\Types\TypeResolver;
 use TheCodingMachine\GraphQL\Controllers\Types\UnionType;
 use Iterator;
 use IteratorAggregate;
@@ -71,13 +71,13 @@ class FieldsBuilder
      */
     private $authorizationService;
     /**
-     * @var ContainerInterface
-     */
-    private $registry;
-    /**
      * @var CachedDocBlockFactory
      */
     private $cachedDocBlockFactory;
+    /**
+     * @var TypeResolver
+     */
+    private $typeResolver;
 
     /**
      * @param AnnotationReader $annotationReader
@@ -85,11 +85,10 @@ class FieldsBuilder
      * @param HydratorInterface $hydrator
      * @param AuthenticationServiceInterface $authenticationService
      * @param AuthorizationServiceInterface $authorizationService
-     * @param ContainerInterface $registry The registry is used to fetch custom return types by container identifier (using the returnType parameter of the Type annotation)
      */
     public function __construct(AnnotationReader $annotationReader, RecursiveTypeMapperInterface $typeMapper,
                                 HydratorInterface $hydrator, AuthenticationServiceInterface $authenticationService,
-                                AuthorizationServiceInterface $authorizationService, ContainerInterface $registry,
+                                AuthorizationServiceInterface $authorizationService, TypeResolver $typeResolver,
                                 CachedDocBlockFactory $cachedDocBlockFactory)
     {
         $this->annotationReader = $annotationReader;
@@ -97,7 +96,7 @@ class FieldsBuilder
         $this->hydrator = $hydrator;
         $this->authenticationService = $authenticationService;
         $this->authorizationService = $authorizationService;
-        $this->registry = $registry;
+        $this->typeResolver = $typeResolver;
         $this->cachedDocBlockFactory = $cachedDocBlockFactory;
     }
 
@@ -198,10 +197,10 @@ class FieldsBuilder
 
                 $args = $this->mapParameters($parameters, $docBlockObj);
 
-                if ($queryAnnotation->getReturnType()) {
-                    $type = $this->registry->get($queryAnnotation->getReturnType());
+                if ($queryAnnotation->getOutputType()) {
+                    $type = $this->typeResolver->mapNameToType($queryAnnotation->getOutputType());
                     if (!$type instanceof OutputType) {
-                        throw new \InvalidArgumentException(sprintf("In %s::%s, the 'returnType' parameter in @Type annotation should contain a container identifier that points to an entry that implements GraphQL\\Type\\Definition\\OutputType. The '%s' container entry does not implement GraphQL\\Type\\Definition\\OutputType", $refMethod->getDeclaringClass()->getName(), $refMethod->getName(), $queryAnnotation->getReturnType()));
+                        throw new \InvalidArgumentException(sprintf("In %s::%s, the 'outputType' parameter in @Type annotation should contain the name of an OutputType. The '%s' type does not implement GraphQL\\Type\\Definition\\OutputType", $refMethod->getDeclaringClass()->getName(), $refMethod->getName(), $queryAnnotation->getOutputType()));
                     }
                 } else {
                     $type = $this->mapReturnType($refMethod, $docBlockObj);
@@ -320,8 +319,8 @@ class FieldsBuilder
                 if (!$refMethod->getReturnType()->allowsNull()) {
                     $type = GraphQLType::nonNull($type);
                 }
-            } elseif ($sourceField->getReturnType()) {
-                $type = $this->registry->get($sourceField->getReturnType());
+            } elseif ($sourceField->getOutputType()) {
+                $type = $this->typeResolver->mapNameToType($sourceField->getOutputType());
             } else {
                 $type = $this->mapReturnType($refMethod, $docBlockObj);
             }

--- a/src/FieldsBuilderFactory.php
+++ b/src/FieldsBuilderFactory.php
@@ -4,12 +4,12 @@
 namespace TheCodingMachine\GraphQL\Controllers;
 
 
-use Psr\Container\ContainerInterface;
 use TheCodingMachine\GraphQL\Controllers\Hydrators\HydratorInterface;
 use TheCodingMachine\GraphQL\Controllers\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQL\Controllers\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQL\Controllers\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQL\Controllers\Security\AuthorizationServiceInterface;
+use TheCodingMachine\GraphQL\Controllers\Types\TypeResolver;
 
 class FieldsBuilderFactory
 {
@@ -30,24 +30,24 @@ class FieldsBuilderFactory
      */
     private $authorizationService;
     /**
-     * @var ContainerInterface
-     */
-    private $registry;
-    /**
      * @var CachedDocBlockFactory
      */
     private $cachedDocBlockFactory;
+    /**
+     * @var TypeResolver
+     */
+    private $typeResolver;
 
     public function __construct(AnnotationReader $annotationReader,
                                 HydratorInterface $hydrator, AuthenticationServiceInterface $authenticationService,
-                                AuthorizationServiceInterface $authorizationService, ContainerInterface $registry,
+                                AuthorizationServiceInterface $authorizationService, TypeResolver $typeResolver,
                                 CachedDocBlockFactory $cachedDocBlockFactory)
     {
         $this->annotationReader = $annotationReader;
         $this->hydrator = $hydrator;
         $this->authenticationService = $authenticationService;
         $this->authorizationService = $authorizationService;
-        $this->registry = $registry;
+        $this->typeResolver = $typeResolver;
         $this->cachedDocBlockFactory = $cachedDocBlockFactory;
     }
 
@@ -63,7 +63,7 @@ class FieldsBuilderFactory
             $this->hydrator,
             $this->authenticationService,
             $this->authorizationService,
-            $this->registry,
+            $this->typeResolver,
             $this->cachedDocBlockFactory
         );
     }

--- a/src/Mappers/StaticTypeMapper.php
+++ b/src/Mappers/StaticTypeMapper.php
@@ -33,14 +33,14 @@ final class StaticTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @var array<string,InputType&Type>
+     * @var array<string,InputObjectType>
      */
     private $inputTypes;
 
     /**
      * An array mapping a fully qualified class name to the matching InputTypeInterface
      *
-     * @param array<string,InputType&Type> $inputTypes
+     * @param array<string,InputObjectType> $inputTypes
      */
     public function setInputTypes(array $inputTypes): void
     {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -8,6 +8,7 @@ use GraphQL\Type\SchemaConfig;
 use TheCodingMachine\GraphQL\Controllers\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQL\Controllers\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQL\Controllers\Types\CustomTypesRegistry;
+use TheCodingMachine\GraphQL\Controllers\Types\TypeResolver;
 
 /**
  * A GraphQL schema that takes into constructor argument a QueryProvider.
@@ -16,7 +17,7 @@ use TheCodingMachine\GraphQL\Controllers\Types\CustomTypesRegistry;
  */
 class Schema extends \GraphQL\Type\Schema
 {
-    public function __construct(QueryProviderInterface $queryProvider, RecursiveTypeMapperInterface $recursiveTypeMapper, SchemaConfig $config = null)
+    public function __construct(QueryProviderInterface $queryProvider, RecursiveTypeMapperInterface $recursiveTypeMapper, TypeResolver $typeResolver, SchemaConfig $config = null)
     {
         if ($config === null) {
             $config = SchemaConfig::create();
@@ -58,6 +59,8 @@ class Schema extends \GraphQL\Type\Schema
 
             return $recursiveTypeMapper->mapNameToType($name);
         });
+
+        $typeResolver->registerSchema($this);
 
         parent::__construct($config);
     }

--- a/src/Types/TypeResolver.php
+++ b/src/Types/TypeResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Types;
+
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use RuntimeException;
+use TheCodingMachine\GraphQL\Controllers\Mappers\CannotMapTypeException;
+
+/**
+ * Resolves a type by its GraphQL name.
+ *
+ * Unlike the TypeMappers, this class can resolve standard GraphQL types (like String, ID, etc...)
+ */
+class TypeResolver
+{
+    /**
+     * @var Schema
+     */
+    private $schema;
+
+    public function registerSchema(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * @param string $typeName
+     * @return Type
+     * @throws CannotMapTypeException
+     */
+    public function mapNameToType(string $typeName): Type
+    {
+        if ($this->schema === null) {
+            throw new RuntimeException('You must register a schema first before resolving types.');
+        }
+        
+        $type = $this->schema->getType($typeName);
+        if ($type === null) {
+            throw CannotMapTypeException::createForName($typeName);
+        }
+
+        return $type;
+    }
+}

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -30,6 +30,7 @@ use TheCodingMachine\GraphQL\Controllers\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQL\Controllers\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQL\Controllers\Security\VoidAuthorizationService;
 use TheCodingMachine\GraphQL\Controllers\Types\ResolvableInputObjectType;
+use TheCodingMachine\GraphQL\Controllers\Types\TypeResolver;
 
 abstract class AbstractQueryProviderTest extends TestCase
 {
@@ -45,6 +46,7 @@ abstract class AbstractQueryProviderTest extends TestCase
     private $inputTypeUtils;
     private $controllerQueryProviderFactory;
     private $annotationReader;
+    private $typeResolver;
 
     protected function getTestObjectType()
     {
@@ -226,9 +228,9 @@ abstract class AbstractQueryProviderTest extends TestCase
     {
         if ($this->registry === null) {
             $this->registry = $this->buildAutoWiringContainer(new Picotainer([
-                'customOutput' => function() {
+                /*'customOutput' => function() {
                     return new StringType();
-                }
+                }*/
             ]));
         }
         return $this->registry;
@@ -255,7 +257,7 @@ abstract class AbstractQueryProviderTest extends TestCase
             $this->getHydrator(),
             new VoidAuthenticationService(),
             new VoidAuthorizationService(),
-            $this->getRegistry(),
+            $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache())
         );
     }
@@ -284,6 +286,15 @@ abstract class AbstractQueryProviderTest extends TestCase
         return $this->inputTypeUtils;
     }
 
+    protected function getTypeResolver(): TypeResolver
+    {
+        if ($this->typeResolver === null) {
+            $this->typeResolver = new TypeResolver();
+            $this->typeResolver->registerSchema(new \GraphQL\Type\Schema([]));
+        }
+        return $this->typeResolver;
+    }
+
     protected function getControllerQueryProviderFactory(): FieldsBuilderFactory
     {
         if ($this->controllerQueryProviderFactory === null) {
@@ -291,7 +302,7 @@ abstract class AbstractQueryProviderTest extends TestCase
                 $this->getHydrator(),
                 new VoidAuthenticationService(),
                 new VoidAuthorizationService(),
-                $this->getRegistry(),
+                $this->getTypeResolver(),
                 new CachedDocBlockFactory(new ArrayCache()));
         }
         return $this->controllerQueryProviderFactory;

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -40,6 +40,7 @@ use TheCodingMachine\GraphQL\Controllers\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQL\Controllers\Security\VoidAuthorizationService;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Query;
 use TheCodingMachine\GraphQL\Controllers\Types\DateTimeType;
+use function var_dump;
 
 class FieldsBuilderTest extends AbstractQueryProviderTest
 {
@@ -143,7 +144,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->assertCount(6, $queries);
         $fixedQuery = $queries[1];
 
-        $this->assertInstanceOf(StringType::class, $fixedQuery->getType());
+        $this->assertInstanceOf(IDType::class, $fixedQuery->getType());
     }
 
     public function testNameFromAnnotation()
@@ -191,7 +192,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
                 }
             },
             new VoidAuthorizationService(),
-            new EmptyContainer(),
+            $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache())
         );
 
@@ -214,7 +215,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
                 {
                     return true;
                 }
-            },new EmptyContainer(),
+            },
+            $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache())
         );
 
@@ -270,7 +272,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             $this->getHydrator(),
             new VoidAuthenticationService(),
             new VoidAuthorizationService(),
-            new EmptyContainer(),
+            $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache())
         );
         $fields = $queryProvider->getFields(new TestTypeWithSourceFieldInterface());

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -64,7 +64,7 @@ class TestController
     }
 
     /**
-     * @Query(returnType="customOutput")
+     * @Query(outputType="ID")
      */
     public function testFixReturnType(): TestObject
     {

--- a/tests/Types/TypeResolverTest.php
+++ b/tests/Types/TypeResolverTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers\Types;
+
+use GraphQL\Type\Definition\IDType;
+use GraphQL\Type\Schema;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use TheCodingMachine\GraphQL\Controllers\Mappers\CannotMapTypeException;
+
+class TypeResolverTest extends TestCase
+{
+    public function testException()
+    {
+        $typeResolver = new TypeResolver();
+        $this->expectException(RuntimeException::class);
+        $typeResolver->mapNameToType('ID');
+    }
+
+    public function testMapNameToType()
+    {
+        $typeResolver = new TypeResolver();
+        $schema = new Schema([]);
+        $typeResolver->registerSchema($schema);
+        $this->assertInstanceOf(IDType::class, $typeResolver->mapNameToType('ID'));
+
+        $this->expectException(CannotMapTypeException::class);
+        $typeResolver->mapNameToType('NotExists');
+    }
+}


### PR DESCRIPTION
Now, in @Query, @SourceField annotations, etc... you should use outputType and give a GraphQL output type name (instead of a container entry resolving to an output type)