### PR TITLE
Adding a "lax" mode for annotation exceptions

### DIFF
--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -41,7 +41,7 @@ class AnnotationReader
     /**
      * If true, no exceptions will be thrown for incorrect annotations in code coming from the "vendor/" directory.
      *
-     * @var bool
+     * @var string
      */
     private $mode;
 
@@ -119,17 +119,21 @@ class AnnotationReader
     private function getClassAnnotation(ReflectionClass $refClass, string $annotationClass)
     {
         do {
+            $type = null;
             try {
                 $type = $this->reader->getClassAnnotation($refClass, $annotationClass);
             } catch (AnnotationException $e) {
-                if ($this->mode === self::STRICT_MODE) {
-                    throw $e;
-                } elseif ($this->mode === self::LAX_MODE) {
-                    if ($this->isErrorImportant($annotationClass, $refClass->getDocComment(), $refClass->getName())) {
+                switch ($this->mode) {
+                    case self::STRICT_MODE:
                         throw $e;
-                    } else {
-                        return null;
-                    }
+                    case self::LAX_MODE:
+                        if ($this->isErrorImportant($annotationClass, $refClass->getDocComment(), $refClass->getName())) {
+                            throw $e;
+                        } else {
+                            return null;
+                        }
+                    default:
+                        throw new \RuntimeException("Unexpected mode '$this->mode'."); // @codeCoverageIgnore
                 }
             }
             if ($type !== null) {

--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -4,9 +4,13 @@
 namespace TheCodingMachine\GraphQL\Controllers;
 
 
+use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\Reader;
+use function in_array;
 use ReflectionClass;
 use ReflectionMethod;
+use function strpos;
+use function substr;
 use TheCodingMachine\GraphQL\Controllers\Annotations\AbstractRequest;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Exceptions\ClassNotFoundException;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Factory;
@@ -22,13 +26,44 @@ class AnnotationReader
      */
     private $reader;
 
-    public function __construct(Reader $reader)
+    // In this mode, no exceptions will be thrown for incorrect annotations (unless the name of the annotation we are looking for is part of the docblock)
+    const LAX_MODE = 'LAX_MODE';
+    // In this mode, exceptions will be thrown for any incorrect annotations.
+    const STRICT_MODE = 'STRICT_MODE';
+
+    /**
+     * Classes in those namespaces MUST have valid annotations (otherwise, an error is thrown).
+     *
+     * @var string[]
+     */
+    private $strictNamespaces;
+
+    /**
+     * If true, no exceptions will be thrown for incorrect annotations in code coming from the "vendor/" directory.
+     *
+     * @var bool
+     */
+    private $mode;
+
+    /**
+     * AnnotationReader constructor.
+     * @param Reader $reader
+     * @param string $mode One of self::LAX_MODE or self::STRICT_MODE
+     * @param array $strictNamespaces
+     */
+    public function __construct(Reader $reader, string $mode = self::STRICT_MODE, array $strictNamespaces = [])
     {
         $this->reader = $reader;
+        if (!in_array($mode, [self::LAX_MODE, self::STRICT_MODE], true)) {
+            throw new \InvalidArgumentException('The mode passed must be one of AnnotationReader::LAX_MODE, AnnotationReader::STRICT_MODE');
+        }
+        $this->mode = $mode;
+        $this->strictNamespaces = $strictNamespaces;
     }
 
     public function getTypeAnnotation(ReflectionClass $refClass): ?Type
     {
+        // TODO: customize the way errors are handled here!
         try {
             /** @var Type|null $typeField */
             $typeField = $this->getClassAnnotation($refClass, Type::class);
@@ -65,10 +100,7 @@ class AnnotationReader
     public function getSourceFields(ReflectionClass $refClass): array
     {
         /** @var SourceField[] $sourceFields */
-        $sourceFields = $this->getClassAnnotations($refClass);
-        $sourceFields = \array_filter($sourceFields, function($annotation): bool {
-            return $annotation instanceof SourceField;
-        });
+        $sourceFields = $this->getClassAnnotations($refClass, SourceField::class);
         return $sourceFields;
     }
 
@@ -87,7 +119,19 @@ class AnnotationReader
     private function getClassAnnotation(ReflectionClass $refClass, string $annotationClass)
     {
         do {
-            $type = $this->reader->getClassAnnotation($refClass, $annotationClass);
+            try {
+                $type = $this->reader->getClassAnnotation($refClass, $annotationClass);
+            } catch (AnnotationException $e) {
+                if ($this->mode === self::STRICT_MODE) {
+                    throw $e;
+                } elseif ($this->mode === self::LAX_MODE) {
+                    if ($this->isErrorImportant($annotationClass, $refClass->getDocComment(), $refClass->getName())) {
+                        throw $e;
+                    } else {
+                        return null;
+                    }
+                }
+            }
             if ($type !== null) {
                 return $type;
             }
@@ -97,18 +141,50 @@ class AnnotationReader
     }
 
     /**
+     * Returns true if the annotation class name is part of the docblock comment.
+     *
+     */
+    private function isErrorImportant(string $annotationClass, string $docComment, string $className): bool
+    {
+        foreach ($this->strictNamespaces as $strictNamespace) {
+            if (strpos($className, $strictNamespace) === 0) {
+                return true;
+            }
+        }
+        $shortAnnotationClass = substr($annotationClass, strrpos($annotationClass, '\\') + 1);
+        return strpos($docComment, '@'.$shortAnnotationClass) !== false;
+    }
+
+    /**
      * Returns the class annotations. Finds in the parents too.
      *
      * @return object[]
      */
-    public function getClassAnnotations(ReflectionClass $refClass): array
+    public function getClassAnnotations(ReflectionClass $refClass, string $annotationClass): array
     {
-        $annotations = [];
+        $toAddAnnotations = [];
         do {
-            $annotations = array_merge($this->reader->getClassAnnotations($refClass), $annotations);
+            try {
+                $allAnnotations = $this->reader->getClassAnnotations($refClass);
+                $toAddAnnotations[] = \array_filter($allAnnotations, function($annotation) use ($annotationClass): bool {
+                    return $annotation instanceof $annotationClass;
+                });
+            } catch (AnnotationException $e) {
+                if ($this->mode === self::STRICT_MODE) {
+                    throw $e;
+                } elseif ($this->mode === self::LAX_MODE) {
+                    if ($this->isErrorImportant($annotationClass, $refClass->getDocComment(), $refClass->getName())) {
+                        throw $e;
+                    }
+                }
+            }
             $refClass = $refClass->getParentClass();
         } while ($refClass);
-        return $annotations;
-    }
 
+        if (!empty($toAddAnnotations)) {
+            return array_merge(...$toAddAnnotations);
+        } else {
+            return [];
+        }
+    }
 }

--- a/tests/AnnotationReaderTest.php
+++ b/tests/AnnotationReaderTest.php
@@ -7,6 +7,8 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
 use ReflectionClass;
+use ReflectionMethod;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Field;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Type;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\Annotations\ClassWithInvalidClassAnnotation;
 use TheCodingMachine\GraphQL\Controllers\Fixtures\Annotations\ClassWithInvalidTypeAnnotation;
@@ -83,5 +85,27 @@ class AnnotationReaderTest extends TestCase
         $annotationReader->getClassAnnotations(new ReflectionClass(ClassWithInvalidClassAnnotation::class), Type::class);
     }
 
+    public function testMethodStrictMode()
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader(), AnnotationReader::STRICT_MODE, []);
 
+        $this->expectException(AnnotationException::class);
+        $annotationReader->getRequestAnnotation(new ReflectionMethod(ClassWithInvalidClassAnnotation::class, 'testMethod'), Field::class);
+    }
+
+    public function testMethodLaxModeWithBadAnnotation()
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader(), AnnotationReader::LAX_MODE, []);
+
+        $type = $annotationReader->getRequestAnnotation(new ReflectionMethod(ClassWithInvalidClassAnnotation::class, 'testMethod'), Field::class);
+        $this->assertNull($type);
+    }
+
+    public function testMethodLaxModeWithSmellyAnnotation()
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader(), AnnotationReader::LAX_MODE, []);
+
+        $this->expectException(AnnotationException::class);
+        $annotationReader->getRequestAnnotation(new ReflectionMethod(ClassWithInvalidTypeAnnotation::class, 'testMethod'), Field::class);
+    }
 }

--- a/tests/AnnotationReaderTest.php
+++ b/tests/AnnotationReaderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+use Doctrine\Common\Annotations\AnnotationException;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
+use ReflectionClass;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Type;
+use TheCodingMachine\GraphQL\Controllers\Fixtures\Annotations\ClassWithInvalidClassAnnotation;
+use TheCodingMachine\GraphQL\Controllers\Fixtures\Annotations\ClassWithInvalidTypeAnnotation;
+
+class AnnotationReaderTest extends TestCase
+{
+    public function testBadConstructor()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new AnnotationReader(new DoctrineAnnotationReader(), 'foo');
+    }
+
+    public function testStrictMode()
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader(), AnnotationReader::STRICT_MODE, []);
+
+        $this->expectException(AnnotationException::class);
+        $annotationReader->getTypeAnnotation(new ReflectionClass(ClassWithInvalidClassAnnotation::class));
+    }
+
+    public function testLaxModeWithBadAnnotation()
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader(), AnnotationReader::LAX_MODE, []);
+
+        $type = $annotationReader->getTypeAnnotation(new ReflectionClass(ClassWithInvalidClassAnnotation::class));
+        $this->assertNull($type);
+    }
+
+    public function testLaxModeWithSmellyAnnotation()
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader(), AnnotationReader::LAX_MODE, []);
+
+        $this->expectException(AnnotationException::class);
+        $annotationReader->getTypeAnnotation(new ReflectionClass(ClassWithInvalidTypeAnnotation::class));
+    }
+
+    public function testLaxModeWithBadAnnotationAndStrictNamespace()
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader(), AnnotationReader::LAX_MODE, ['TheCodingMachine\\GraphQL\\Controllers\\Fixtures']);
+
+        $this->expectException(AnnotationException::class);
+        $annotationReader->getTypeAnnotation(new ReflectionClass(ClassWithInvalidClassAnnotation::class));
+    }
+
+    public function testGetAnnotationsStrictMode()
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader(), AnnotationReader::STRICT_MODE, []);
+
+        $this->expectException(AnnotationException::class);
+        $annotationReader->getClassAnnotations(new ReflectionClass(ClassWithInvalidClassAnnotation::class), Type::class);
+    }
+
+    public function testGetAnnotationsLaxModeWithBadAnnotation()
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader(), AnnotationReader::LAX_MODE, []);
+
+        $types = $annotationReader->getClassAnnotations(new ReflectionClass(ClassWithInvalidClassAnnotation::class), Type::class);
+        $this->assertSame([], $types);
+    }
+
+    public function testGetAnnotationsLaxModeWithSmellyAnnotation()
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader(), AnnotationReader::LAX_MODE, []);
+
+        $this->expectException(AnnotationException::class);
+        $annotationReader->getClassAnnotations(new ReflectionClass(ClassWithInvalidTypeAnnotation::class), Type::class);
+    }
+
+    public function testGetAnnotationsLaxModeWithBadAnnotationAndStrictNamespace()
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader(), AnnotationReader::LAX_MODE, ['TheCodingMachine\\GraphQL\\Controllers\\Fixtures']);
+
+        $this->expectException(AnnotationException::class);
+        $annotationReader->getClassAnnotations(new ReflectionClass(ClassWithInvalidClassAnnotation::class), Type::class);
+    }
+
+
+}

--- a/tests/Fixtures/Annotations/ClassWithInvalidClassAnnotation.php
+++ b/tests/Fixtures/Annotations/ClassWithInvalidClassAnnotation.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Fixtures\Annotations;
+
+/**
+ * No namespace here
+ *
+ * @foo()
+ */
+class ClassWithInvalidClassAnnotation
+{
+
+}

--- a/tests/Fixtures/Annotations/ClassWithInvalidClassAnnotation.php
+++ b/tests/Fixtures/Annotations/ClassWithInvalidClassAnnotation.php
@@ -10,5 +10,11 @@ namespace TheCodingMachine\GraphQL\Controllers\Fixtures\Annotations;
  */
 class ClassWithInvalidClassAnnotation
 {
+    /**
+     * @foo
+     */
+    public function testMethod()
+    {
 
+    }
 }

--- a/tests/Fixtures/Annotations/ClassWithInvalidTypeAnnotation.php
+++ b/tests/Fixtures/Annotations/ClassWithInvalidTypeAnnotation.php
@@ -10,5 +10,11 @@ namespace TheCodingMachine\GraphQL\Controllers\Fixtures\Annotations;
  */
 class ClassWithInvalidTypeAnnotation
 {
+    /**
+     * @Field
+     */
+    public function testMethod()
+    {
 
+    }
 }

--- a/tests/Fixtures/Annotations/ClassWithInvalidTypeAnnotation.php
+++ b/tests/Fixtures/Annotations/ClassWithInvalidTypeAnnotation.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Fixtures\Annotations;
+
+/**
+ * No namespace here
+ *
+ * @Type()
+ */
+class ClassWithInvalidTypeAnnotation
+{
+
+}


### PR DESCRIPTION
This allows more stable code for implementations scanning a lot of classes (i.e. the Symfony bundle)