### PR TITLE
Adding failWith annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,37 @@ class UserController
 }
 ```
 
+Note: when you use the `@Logged` or `@Right` annotation, the field will NOT be part of the GraphQL schema
+if the current user is not logged or has not the requested right.
+
+This is a good thing as unprivileged users will not even be aware of the existence of the fields they are not supposed to see.
+This can however be a problem with some GraphQL clients as the schema is changing from one user to another.
+
+If you want to keep a constant schema, you can use the `FailWith` annotation that contains the value that
+will be returned for user with insufficient rights.
+
+```php
+class UserController
+{
+    /**
+     * If a user is not logged or if the user has not the right "CAN_VIEW_USER_LIST",
+     * the value returned will be "null"
+     *
+     * @Query
+     * @Logged
+     * @Right("CAN_VIEW_USER_LIST")
+     * @FailWith(null)
+     * @return User[]
+     */
+    public function users(int $limit, int $offset): array
+    {
+        //
+    }
+}
+```
+ 
+
+
 Type-hinting against arrays
 ---------------------------
 
@@ -376,6 +407,20 @@ class PostType extends AbstractAnnotatedObjectType
 {
 }
 ```
+
+Just like the `@Logged` and `@Right` annotations for regular fields, you can define a default value to use
+in case the user has insufficient permissions:
+
+```php
+/**
+ * @SourceField(name="status", logged=true, right=@Right(name="CAN_ACCESS_STATUS"), failWith=null)
+ */
+```
+
+The `failWith` value will be returned in case of insufficient permissions. Note that if you do not put the
+`failWith` attribute and if a user has insufficient permissions, then the field will not appear at all in the schema.
+Querying this field will therefore result in an error. 
+
 
 In some very particular cases, you might not know exactly the list of @SourceField annotations at development time.
 If you need to decide the list of @SourceField at runtime, you can implement the `FromSourceFieldsInterface`:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,6 @@ parameters:
     ignoreErrors:
         - "#PHPDoc tag \\@throws with type Psr\\\\Container\\\\ContainerExceptionInterface is not subtype of Throwable#"
         - "#Property TheCodingMachine\\\\GraphQL\\\\Controllers\\\\Types\\\\ResolvableInputObjectType::$resolve \\(array<int, object|string>&callable\\) does not accept array<int,object|string>#"
+        - "#Variable \\$failWith might not be defined#"
 #includes:
 #    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -14,6 +14,7 @@ use function substr;
 use TheCodingMachine\GraphQL\Controllers\Annotations\AbstractRequest;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Exceptions\ClassNotFoundException;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Factory;
+use TheCodingMachine\GraphQL\Controllers\Annotations\FailWith;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Logged;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Right;
 use TheCodingMachine\GraphQL\Controllers\Annotations\SourceField;
@@ -92,6 +93,13 @@ class AnnotationReader
         /** @var Right|null $rightAnnotation */
         $rightAnnotation = $this->getMethodAnnotation($refMethod, Right::class);
         return $rightAnnotation;
+    }
+
+    public function getFailWithAnnotation(ReflectionMethod $refMethod): ?FailWith
+    {
+        /** @var FailWith|null $failWithAnnotation */
+        $failWithAnnotation = $this->getMethodAnnotation($refMethod, FailWith::class);
+        return $failWithAnnotation;
     }
 
     /**

--- a/src/Annotations/FailWith.php
+++ b/src/Annotations/FailWith.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Annotations;
+
+use function array_key_exists;
+
+/**
+ * @Annotation
+ * @Target({"METHOD"})
+ */
+class FailWith
+{
+    /**
+     * The default value to use if the right is not enforced.
+     *
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __construct(array $values)
+    {
+        if (!array_key_exists('value', $values)) {
+            throw new \BadMethodCallException('The @FailWith annotation must be passed a defaultValue. For instance: "@FailWith(null)"');
+        }
+        $this->value = $values['value'];
+    }
+
+    /**
+     * Returns the default value to use if the right is not enforced.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Annotations/SourceField.php
+++ b/src/Annotations/SourceField.php
@@ -14,7 +14,10 @@ namespace TheCodingMachine\GraphQL\Controllers\Annotations;
  *   @Attribute("right", type = "TheCodingMachine\GraphQL\Controllers\Annotations\Right"),
  *   @Attribute("outputType", type = "string"),
  *   @Attribute("isId", type = "bool"),
+ *   @Attribute("failWith", type = "mixed"),
  * })
+ *
+ * FIXME: remove idId since outputType="ID" is equivalent
  */
 class SourceField implements SourceFieldInterface
 {
@@ -44,6 +47,18 @@ class SourceField implements SourceFieldInterface
     private $id;
 
     /**
+     * The default value to use if the right is not enforced.
+     *
+     * @var mixed
+     */
+    private $failWith;
+
+    /**
+     * @var bool
+     */
+    private $hasFailWith = false;
+
+    /**
      * @param mixed[] $attributes
      */
     public function __construct(array $attributes = [])
@@ -53,6 +68,10 @@ class SourceField implements SourceFieldInterface
         $this->right = $attributes['right'] ?? null;
         $this->outputType = $attributes['outputType'] ?? null;
         $this->id = $attributes['isId'] ?? false;
+        if (array_key_exists('failWith', $attributes)) {
+            $this->failWith = $attributes['failWith'];
+            $this->hasFailWith = true;
+        }
     }
 
     /**
@@ -103,5 +122,25 @@ class SourceField implements SourceFieldInterface
     public function isId(): bool
     {
         return $this->id;
+    }
+
+    /**
+     * Returns the default value to use if the right is not enforced.
+     *
+     * @return mixed
+     */
+    public function getFailWith()
+    {
+        return $this->failWith;
+    }
+
+    /**
+     * True if a default value is available if a right is not enforced.
+     *
+     * @return bool
+     */
+    public function canFailWith(): bool
+    {
+        return $this->hasFailWith;
     }
 }

--- a/src/Annotations/SourceFieldInterface.php
+++ b/src/Annotations/SourceFieldInterface.php
@@ -42,4 +42,18 @@ interface SourceFieldInterface
      * @return bool
      */
     public function isId(): bool;
+
+    /**
+     * Returns the default value to use if the right is not enforced.
+     *
+     * @return mixed
+     */
+    public function getFailWith();
+
+    /**
+     * True if a default value is available if a right is not enforced.
+     *
+     * @return bool
+     */
+    public function canFailWith();
 }

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -3,6 +3,7 @@
 
 namespace TheCodingMachine\GraphQL\Controllers\Annotations;
 
+use BadMethodCallException;
 use function class_exists;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Exceptions\ClassNotFoundException;
 use TheCodingMachine\GraphQL\Controllers\MissingAnnotationException;
@@ -30,7 +31,7 @@ class Type
     public function __construct(array $attributes = [])
     {
         if (!isset($attributes['class'])) {
-            throw new MissingAnnotationException('In annotation @Type, missing compulsory parameter "class".');
+            throw new BadMethodCallException('In annotation @Type, missing compulsory parameter "class".');
         }
         $this->className = $attributes['class'];
         if (!class_exists($this->className)) {

--- a/tests/Annotations/FailWithTest.php
+++ b/tests/Annotations/FailWithTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers\Annotations;
+
+use BadMethodCallException;
+use PHPUnit\Framework\TestCase;
+
+class FailWithTest extends TestCase
+{
+
+    public function testException()
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('The @FailWith annotation must be passed a defaultValue. For instance: "@FailWith(null)"');
+        new FailWith([]);
+    }
+}

--- a/tests/Annotations/RightTest.php
+++ b/tests/Annotations/RightTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers\Annotations;
+
+use BadMethodCallException;
+use PHPUnit\Framework\TestCase;
+
+class RightTest extends TestCase
+{
+
+    public function testException()
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('The @Right annotation must be passed a right name. For instance: "@Right(\'my_right\')"');
+        new Right([]);
+    }
+}

--- a/tests/Annotations/TypeTest.php
+++ b/tests/Annotations/TypeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers\Annotations;
+
+use BadMethodCallException;
+use PHPUnit\Framework\TestCase;
+
+class TypeTest extends TestCase
+{
+
+    public function testException()
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('In annotation @Type, missing compulsory parameter "class".');
+        new Type([]);
+    }
+}

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -442,5 +442,13 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $this->assertSame('test', $fields['test']->name);
         $this->assertInstanceOf(StringType::class, $fields['test']->getType());
+
+
+        $resolve = $fields['test']->resolveFn;
+        $result = $resolve('foo', []);
+
+        $this->assertNull($result);
+
+        $this->assertInstanceOf(StringType::class, $fields['test']->getType());
     }
 }

--- a/tests/Fixtures/TestControllerWithFailWith.php
+++ b/tests/Fixtures/TestControllerWithFailWith.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Fixtures;
+
+use ArrayObject;
+use TheCodingMachine\GraphQL\Controllers\Annotations\FailWith;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Logged;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Mutation;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Query;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Right;
+
+class TestControllerWithFailWith
+{
+    /**
+     * @Query
+     * @Logged
+     * @FailWith(null)
+     */
+    public function testFailWith(): TestObject
+    {
+        return new TestObject('foo');
+    }
+}

--- a/tests/Fixtures/TestTypeWithFailWith.php
+++ b/tests/Fixtures/TestTypeWithFailWith.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Fixtures;
+
+use TheCodingMachine\GraphQL\Controllers\Annotations\Right;
+use TheCodingMachine\GraphQL\Controllers\Annotations\SourceField;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Field;
+use TheCodingMachine\GraphQL\Controllers\Annotations\Type;
+
+/**
+ * @Type(class=TestObject::class)
+ * @SourceField(name="test", right=@Right(name="FOOBAR"), failWith=null)
+ */
+class TestTypeWithFailWith
+{
+}


### PR DESCRIPTION
The FailWith annotation allows to keep a constant schema when a user is not logged / has no rights.