### PR TITLE
Getter fields/queries names are transformed in field name

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -82,18 +82,15 @@ class FieldsBuilder
      * @var TypeResolver
      */
     private $typeResolver;
-
     /**
-     * @param AnnotationReader $annotationReader
-     * @param RecursiveTypeMapperInterface $typeMapper
-     * @param HydratorInterface $hydrator
-     * @param AuthenticationServiceInterface $authenticationService
-     * @param AuthorizationServiceInterface $authorizationService
+     * @var NamingStrategyInterface
      */
+    private $namingStrategy;
+
     public function __construct(AnnotationReader $annotationReader, RecursiveTypeMapperInterface $typeMapper,
                                 HydratorInterface $hydrator, AuthenticationServiceInterface $authenticationService,
                                 AuthorizationServiceInterface $authorizationService, TypeResolver $typeResolver,
-                                CachedDocBlockFactory $cachedDocBlockFactory)
+                                CachedDocBlockFactory $cachedDocBlockFactory, NamingStrategyInterface $namingStrategy)
     {
         $this->annotationReader = $annotationReader;
         $this->typeMapper = $typeMapper;
@@ -102,6 +99,7 @@ class FieldsBuilder
         $this->authorizationService = $authorizationService;
         $this->typeResolver = $typeResolver;
         $this->cachedDocBlockFactory = $cachedDocBlockFactory;
+        $this->namingStrategy = $namingStrategy;
     }
 
     // TODO: Add RecursiveTypeMapper in the list of parameters for getQueries and REMOVE the ControllerQueryProviderFactory.
@@ -217,7 +215,7 @@ class FieldsBuilder
                 $docBlockComment = $docBlockObj->getSummary()."\n".$docBlockObj->getDescription()->render();
 
                 $methodName = $refMethod->getName();
-                $name = $queryAnnotation->getName() ?: $methodName;
+                $name = $queryAnnotation->getName() ?: $this->namingStrategy->getFieldNameFromMethodName($methodName);
 
                 $parameters = $refMethod->getParameters();
                 if ($injectSource === true) {

--- a/src/FieldsBuilderFactory.php
+++ b/src/FieldsBuilderFactory.php
@@ -37,11 +37,15 @@ class FieldsBuilderFactory
      * @var TypeResolver
      */
     private $typeResolver;
+    /**
+     * @var NamingStrategyInterface
+     */
+    private $namingStrategy;
 
     public function __construct(AnnotationReader $annotationReader,
                                 HydratorInterface $hydrator, AuthenticationServiceInterface $authenticationService,
                                 AuthorizationServiceInterface $authorizationService, TypeResolver $typeResolver,
-                                CachedDocBlockFactory $cachedDocBlockFactory)
+                                CachedDocBlockFactory $cachedDocBlockFactory, NamingStrategyInterface $namingStrategy)
     {
         $this->annotationReader = $annotationReader;
         $this->hydrator = $hydrator;
@@ -49,6 +53,7 @@ class FieldsBuilderFactory
         $this->authorizationService = $authorizationService;
         $this->typeResolver = $typeResolver;
         $this->cachedDocBlockFactory = $cachedDocBlockFactory;
+        $this->namingStrategy = $namingStrategy;
     }
 
     /**
@@ -64,7 +69,8 @@ class FieldsBuilderFactory
             $this->authenticationService,
             $this->authorizationService,
             $this->typeResolver,
-            $this->cachedDocBlockFactory
+            $this->cachedDocBlockFactory,
+            $this->namingStrategy
         );
     }
 }

--- a/src/NamingStrategy.php
+++ b/src/NamingStrategy.php
@@ -4,6 +4,10 @@
 namespace TheCodingMachine\GraphQL\Controllers;
 
 
+use function lcfirst;
+use function strlen;
+use function strpos;
+use function substr;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Factory;
 use TheCodingMachine\GraphQL\Controllers\Annotations\Type;
 
@@ -48,5 +52,20 @@ class NamingStrategy implements NamingStrategyInterface
             $className = substr($className, $prevPos + 1);
         }
         return $className.'Input';
+    }
+
+    /**
+     * Returns the name of a GraphQL field from the name of the annotated method.
+     */
+    public function getFieldNameFromMethodName(string $methodName): string
+    {
+        // Let's remove any "get" or "is".
+        if (strpos($methodName, 'get') === 0 && strlen($methodName) > 3) {
+            return lcfirst(substr($methodName, 3));
+        }
+        if (strpos($methodName, 'is') === 0 && strlen($methodName) > 2) {
+            return lcfirst(substr($methodName, 2));
+        }
+        return $methodName;
     }
 }

--- a/src/NamingStrategyInterface.php
+++ b/src/NamingStrategyInterface.php
@@ -19,4 +19,9 @@ interface NamingStrategyInterface
     public function getOutputTypeName(string $typeClassName, Type $type): string;
 
     public function getInputTypeName(string $className, Factory $factory): string;
+
+    /**
+     * Returns the name of a GraphQL field from the name of the annotated method.
+     */
+    public function getFieldNameFromMethodName(string $methodName): string;
 }

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -259,7 +259,8 @@ abstract class AbstractQueryProviderTest extends TestCase
             new VoidAuthenticationService(),
             new VoidAuthorizationService(),
             $this->getTypeResolver(),
-            new CachedDocBlockFactory(new ArrayCache())
+            new CachedDocBlockFactory(new ArrayCache()),
+            new NamingStrategy()
         );
     }
 
@@ -304,7 +305,8 @@ abstract class AbstractQueryProviderTest extends TestCase
                 new VoidAuthenticationService(),
                 new VoidAuthorizationService(),
                 $this->getTypeResolver(),
-                new CachedDocBlockFactory(new ArrayCache()));
+                new CachedDocBlockFactory(new ArrayCache()),
+                new NamingStrategy());
         }
         return $this->controllerQueryProviderFactory;
     }

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -195,7 +195,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             },
             new VoidAuthorizationService(),
             $this->getTypeResolver(),
-            new CachedDocBlockFactory(new ArrayCache())
+            new CachedDocBlockFactory(new ArrayCache()),
+            new NamingStrategy()
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -219,7 +220,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
                 }
             },
             $this->getTypeResolver(),
-            new CachedDocBlockFactory(new ArrayCache())
+            new CachedDocBlockFactory(new ArrayCache()),
+            new NamingStrategy()
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -275,7 +277,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             new VoidAuthenticationService(),
             new VoidAuthorizationService(),
             $this->getTypeResolver(),
-            new CachedDocBlockFactory(new ArrayCache())
+            new CachedDocBlockFactory(new ArrayCache()),
+            new NamingStrategy()
         );
         $fields = $queryProvider->getFields(new TestTypeWithSourceFieldInterface(), true);
         $this->assertCount(1, $fields);

--- a/tests/Fixtures/Integration/Models/Product.php
+++ b/tests/Fixtures/Integration/Models/Product.php
@@ -44,7 +44,7 @@ class Product
     }
 
     /**
-     * @Field(name="price")
+     * @Field()
      * @return float
      */
     public function getPrice(): float

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -71,7 +71,8 @@ class EndToEndTest extends TestCase
                     $container->get(AuthenticationServiceInterface::class),
                     $container->get(AuthorizationServiceInterface::class),
                     $container->get(TypeResolver::class),
-                    $container->get(CachedDocBlockFactory::class)
+                    $container->get(CachedDocBlockFactory::class),
+                    $container->get(NamingStrategyInterface::class)
                 );
             },
             TypeResolver::class => function(ContainerInterface $container) {
@@ -179,7 +180,7 @@ class EndToEndTest extends TestCase
 
         $queryString = '
         query {
-            getContacts {
+            contacts {
                 name
                 uppercaseName
                 ... on User {
@@ -195,7 +196,7 @@ class EndToEndTest extends TestCase
         );
 
         $this->assertSame([
-            'getContacts' => [
+            'contacts' => [
                 [
                     'name' => 'Joe',
                     'uppercaseName' => 'JOE'
@@ -216,7 +217,7 @@ class EndToEndTest extends TestCase
         );
 
         $this->assertSame([
-            'getContacts' => [
+            'contacts' => [
                 [
                     'name' => 'Joe',
                     'uppercaseName' => 'JOE'
@@ -289,7 +290,7 @@ class EndToEndTest extends TestCase
 
         $queryString = '
         query {
-            getContactsIterator {
+            contactsIterator {
                 items(limit: 1, offset: 1) {
                     name
                     uppercaseName
@@ -308,7 +309,7 @@ class EndToEndTest extends TestCase
         );
 
         $this->assertSame([
-            'getContactsIterator' => [
+            'contactsIterator' => [
                 'items' => [
                     [
                         'name' => 'Bill',
@@ -327,7 +328,7 @@ class EndToEndTest extends TestCase
         );
 
         $this->assertSame([
-            'getContactsIterator' => [
+            'contactsIterator' => [
                 'items' => [
                     [
                         'name' => 'Bill',
@@ -342,7 +343,7 @@ class EndToEndTest extends TestCase
         // Let's run a query with no limit but an offset
         $invalidQueryString = '
         query {
-            getContactsIterator {
+            contactsIterator {
                 items(offset: 1) {
                     name
                     ... on User {
@@ -365,7 +366,7 @@ class EndToEndTest extends TestCase
         // Let's run a query with no limit offset
         $invalidQueryString = '
         query {
-            getContactsIterator {
+            contactsIterator {
                 items {
                     name
                     ... on User {
@@ -383,7 +384,7 @@ class EndToEndTest extends TestCase
         );
 
         $this->assertSame([
-            'getContactsIterator' => [
+            'contactsIterator' => [
                 'items' => [
                     [
                         'name' => 'Joe',
@@ -410,7 +411,7 @@ class EndToEndTest extends TestCase
 
         $queryString = '
         query {
-            getContactsIterator {
+            contactsIterator {
                 items(limit: 1, offset: 1) {
                     name
                     uppercaseName
@@ -421,7 +422,7 @@ class EndToEndTest extends TestCase
                 count
             }
             
-            getProducts {
+            products {
                 items {
                     name
                     price
@@ -437,7 +438,7 @@ class EndToEndTest extends TestCase
         );
 
         $this->assertSame([
-            'getContactsIterator' => [
+            'contactsIterator' => [
                 'items' => [
                     [
                         'name' => 'Bill',
@@ -447,7 +448,7 @@ class EndToEndTest extends TestCase
                 ],
                 'count' => 2
             ],
-            'getProducts' => [
+            'products' => [
                 'items' => [
                     [
                         'name' => 'Foo',

--- a/tests/NamingStrategyTest.php
+++ b/tests/NamingStrategyTest.php
@@ -18,4 +18,15 @@ class NamingStrategyTest extends TestCase
         $factory = new Factory(['name'=>'MyInputType']);
         $this->assertSame('MyInputType', $namingStrategy->getInputTypeName('Bar\\FooClass', $factory));
     }
+
+    public function testGetFieldNameFromMethodName(): void
+    {
+        $namingStrategy = new NamingStrategy();
+
+        $this->assertSame('name', $namingStrategy->getFieldNameFromMethodName('getName'));
+        $this->assertSame('get', $namingStrategy->getFieldNameFromMethodName('get'));
+        $this->assertSame('name', $namingStrategy->getFieldNameFromMethodName('isName'));
+        $this->assertSame('is', $namingStrategy->getFieldNameFromMethodName('is'));
+        $this->assertSame('foo', $namingStrategy->getFieldNameFromMethodName('foo'));
+    }
 }


### PR DESCRIPTION
Fields with the "getter" naming convention are turned automatically into a naming without a "get".

For instance: "getProducts" method will generate a "products"  query/field.