### PR TITLE
Adding a SchemaFactory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "webonyx/graphql-php": "^0.13",
         "psr/container": "^1",
         "doctrine/annotations": "^1.2",
+        "doctrine/cache": "^1.8",
         "thecodingmachine/class-explorer": "^1.1",
         "psr/simple-cache": "^1",
         "phpdocumentor/reflection-docblock": "^4.3",

--- a/src/GlobControllerQueryProvider.php
+++ b/src/GlobControllerQueryProvider.php
@@ -44,7 +44,7 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
     /**
      * @var FieldsBuilderFactory
      */
-    private $controllerQueryProviderFactory;
+    private $fieldsBuilderFactory;
     /**
      * @var RecursiveTypeMapperInterface
      */
@@ -56,20 +56,20 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
 
     /**
      * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
-     * @param FieldsBuilderFactory $controllerQueryProviderFactory
+     * @param FieldsBuilderFactory $fieldsBuilderFactory
      * @param RecursiveTypeMapperInterface $recursiveTypeMapper
      * @param ContainerInterface $container The container we will fetch controllers from.
      * @param CacheInterface $cache
      * @param int|null $cacheTtl
      * @param bool $recursive Whether subnamespaces of $namespace must be analyzed.
      */
-    public function __construct(string $namespace, FieldsBuilderFactory $controllerQueryProviderFactory, RecursiveTypeMapperInterface $recursiveTypeMapper, ContainerInterface $container, CacheInterface $cache, ?int $cacheTtl = null, bool $recursive = true)
+    public function __construct(string $namespace, FieldsBuilderFactory $fieldsBuilderFactory, RecursiveTypeMapperInterface $recursiveTypeMapper, ContainerInterface $container, CacheInterface $cache, ?int $cacheTtl = null, bool $recursive = true)
     {
         $this->namespace = $namespace;
         $this->container = $container;
         $this->cache = $cache;
         $this->cacheTtl = $cacheTtl;
-        $this->controllerQueryProviderFactory = $controllerQueryProviderFactory;
+        $this->fieldsBuilderFactory = $fieldsBuilderFactory;
         $this->recursiveTypeMapper = $recursiveTypeMapper;
         $this->recursive = $recursive;
     }
@@ -77,7 +77,7 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
     private function getAggregateControllerQueryProvider(): AggregateControllerQueryProvider
     {
         if ($this->aggregateControllerQueryProvider === null) {
-            $this->aggregateControllerQueryProvider = new AggregateControllerQueryProvider($this->getInstancesList(), $this->controllerQueryProviderFactory, $this->recursiveTypeMapper, $this->container);
+            $this->aggregateControllerQueryProvider = new AggregateControllerQueryProvider($this->getInstancesList(), $this->fieldsBuilderFactory, $this->recursiveTypeMapper, $this->container);
         }
         return $this->aggregateControllerQueryProvider;
     }

--- a/src/InputTypeGenerator.php
+++ b/src/InputTypeGenerator.php
@@ -24,7 +24,7 @@ class InputTypeGenerator
     /**
      * @var FieldsBuilderFactory
      */
-    private $controllerQueryProviderFactory;
+    private $fieldsBuilderFactory;
     /**
      * @var array<string, InputObjectType>
      */
@@ -39,11 +39,11 @@ class InputTypeGenerator
     private $inputTypeUtils;
 
     public function __construct(InputTypeUtils $inputTypeUtils,
-                                FieldsBuilderFactory $controllerQueryProviderFactory,
+                                FieldsBuilderFactory $fieldsBuilderFactory,
                                 HydratorInterface $hydrator)
     {
         $this->inputTypeUtils = $inputTypeUtils;
-        $this->controllerQueryProviderFactory = $controllerQueryProviderFactory;
+        $this->fieldsBuilderFactory = $fieldsBuilderFactory;
         $this->hydrator = $hydrator;
     }
 
@@ -61,7 +61,7 @@ class InputTypeGenerator
 
         if (!isset($this->cache[$inputName])) {
             // TODO: add comment argument.
-            $this->cache[$inputName] = new ResolvableInputObjectType($inputName, $this->controllerQueryProviderFactory, $recursiveTypeMapper, $factory, $methodName, $this->hydrator, null);
+            $this->cache[$inputName] = new ResolvableInputObjectType($inputName, $this->fieldsBuilderFactory, $recursiveTypeMapper, $factory, $methodName, $this->hydrator, null);
         }
 
         return $this->cache[$inputName];

--- a/src/Mappers/CompositeTypeMapper.php
+++ b/src/Mappers/CompositeTypeMapper.php
@@ -81,8 +81,12 @@ class CompositeTypeMapper implements TypeMapperInterface
     public function getSupportedClasses(): array
     {
         if ($this->supportedClasses === null) {
-            $supportedClassesArrays = array_map(function(TypeMapperInterface $typeMapper) { return $typeMapper->getSupportedClasses(); }, $this->typeMappers);
-            $this->supportedClasses = array_unique(array_merge(...$supportedClassesArrays));
+            if ($this->typeMappers === []) {
+                $this->supportedClasses = [];
+            } else {
+                $supportedClassesArrays = array_map(function(TypeMapperInterface $typeMapper) { return $typeMapper->getSupportedClasses(); }, $this->typeMappers);
+                $this->supportedClasses = array_unique(array_merge(...$supportedClassesArrays));
+            }
         }
         return $this->supportedClasses;
     }

--- a/src/Security/FailAuthenticationService.php
+++ b/src/Security/FailAuthenticationService.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Security;
+
+/**
+ * A fake authentication service that always returns that the current user is NOT authenticated.
+ */
+class FailAuthenticationService implements AuthenticationServiceInterface
+{
+
+    /**
+     * Returns true if the "current" user is logged
+     *
+     * @return bool
+     */
+    public function isLogged(): bool
+    {
+        throw SecurityNotImplementedException::createNoAuthenticationException();
+    }
+}

--- a/src/Security/FailAuthorizationService.php
+++ b/src/Security/FailAuthorizationService.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Security;
+
+/**
+ * A fake authorization service with a user that has no rights
+ */
+class FailAuthorizationService implements AuthorizationServiceInterface
+{
+    /**
+     * Returns true if the "current" user has access to the right "$right"
+     *
+     * @param string $right
+     * @return bool
+     */
+    public function isAllowed(string $right): bool
+    {
+        throw SecurityNotImplementedException::createNoAuthorizationException();
+    }
+}

--- a/src/Security/SecurityNotImplementedException.php
+++ b/src/Security/SecurityNotImplementedException.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQL\Controllers\Security;
+
+
+class SecurityNotImplementedException extends \LogicException
+{
+
+    public static function createNoAuthenticationException(): self
+    {
+        return new self('GraphQL-Controllers does not know how to check for authentication. You probably tried to use the @Logged annotation without configuring first an AuthenticationService.');
+    }
+
+    public static function createNoAuthorizationException(): self
+    {
+        return new self('GraphQL-Controllers does not know how to check for authorization. You probably tried to use the @Right annotation without configuring first an AuthorizationService.');
+    }
+}

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers;
+
+use GraphQL\Error\Debug;
+use GraphQL\GraphQL;
+use GraphQL\Type\SchemaConfig;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Simple\ApcuCache;
+use TheCodingMachine\GraphQL\Controllers\Containers\BasicAutoWiringContainer;
+use TheCodingMachine\GraphQL\Controllers\Containers\EmptyContainer;
+use TheCodingMachine\GraphQL\Controllers\Hydrators\FactoryHydrator;
+use TheCodingMachine\GraphQL\Controllers\Mappers\CompositeTypeMapper;
+use TheCodingMachine\GraphQL\Controllers\Security\VoidAuthenticationService;
+use TheCodingMachine\GraphQL\Controllers\Security\VoidAuthorizationService;
+
+class SchemaFactoryTest extends TestCase
+{
+
+    public function testCreateSchema(): void
+    {
+        $container = new BasicAutoWiringContainer(new EmptyContainer());
+        $cache = new ApcuCache();
+
+        $factory = new SchemaFactory($cache, $container);
+
+        $factory->addControllerNamespace('TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\Integration\\Controllers');
+        $factory->addTypeNamespace('TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\Integration');
+        $factory->addQueryProvider(new AggregateQueryProvider([]));
+
+        $schema = $factory->createSchema();
+
+        $this->doTestSchema($schema);
+    }
+
+    public function testSetters(): void
+    {
+        $container = new BasicAutoWiringContainer(new EmptyContainer());
+        $cache = new ApcuCache();
+
+        $factory = new SchemaFactory($cache, $container);
+
+        $factory->addControllerNamespace('TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\Integration\\Controllers');
+        $factory->addTypeNamespace('TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\Integration');
+        $factory->setDoctrineAnnotationReader(new \Doctrine\Common\Annotations\AnnotationReader())
+                ->setHydrator(new FactoryHydrator())
+                ->setAuthenticationService(new VoidAuthenticationService())
+                ->setAuthorizationService(new VoidAuthorizationService())
+                ->setNamingStrategy(new NamingStrategy())
+                ->addTypeMapper(new CompositeTypeMapper([]))
+                ->setSchemaConfig(new SchemaConfig());
+
+        $schema = $factory->createSchema();
+
+        $this->doTestSchema($schema);
+    }
+
+    public function testException(): void
+    {
+        $container = new BasicAutoWiringContainer(new EmptyContainer());
+        $cache = new ApcuCache();
+
+        $factory = new SchemaFactory($cache, $container);
+
+        $this->expectException(GraphQLException::class);
+        $factory->createSchema();
+    }
+
+    public function testException2(): void
+    {
+        $container = new BasicAutoWiringContainer(new EmptyContainer());
+        $cache = new ApcuCache();
+
+        $factory = new SchemaFactory($cache, $container);
+        $factory->addTypeNamespace('TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\Integration');
+
+        $this->expectException(GraphQLException::class);
+        $factory->createSchema();
+    }
+
+    private function doTestSchema(Schema $schema): void
+    {
+
+        $schema->assertValid();
+
+        $queryString = '
+        query {
+            contacts {
+                name
+                uppercaseName
+                ... on User {
+                    email
+                }
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'contacts' => [
+                [
+                    'name' => 'Joe',
+                    'uppercaseName' => 'JOE'
+                ],
+                [
+                    'name' => 'Bill',
+                    'uppercaseName' => 'BILL',
+                    'email' => 'bill@example.com'
+                ]
+
+            ]
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
+    }
+}

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -6,7 +6,7 @@ use GraphQL\Error\Debug;
 use GraphQL\GraphQL;
 use GraphQL\Type\SchemaConfig;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Cache\Simple\ApcuCache;
+use Symfony\Component\Cache\Simple\PhpFilesCache;
 use TheCodingMachine\GraphQL\Controllers\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQL\Controllers\Containers\EmptyContainer;
 use TheCodingMachine\GraphQL\Controllers\Hydrators\FactoryHydrator;
@@ -20,7 +20,7 @@ class SchemaFactoryTest extends TestCase
     public function testCreateSchema(): void
     {
         $container = new BasicAutoWiringContainer(new EmptyContainer());
-        $cache = new ApcuCache();
+        $cache = new PhpFilesCache();
 
         $factory = new SchemaFactory($cache, $container);
 
@@ -36,7 +36,7 @@ class SchemaFactoryTest extends TestCase
     public function testSetters(): void
     {
         $container = new BasicAutoWiringContainer(new EmptyContainer());
-        $cache = new ApcuCache();
+        $cache = new PhpFilesCache();
 
         $factory = new SchemaFactory($cache, $container);
 
@@ -58,7 +58,7 @@ class SchemaFactoryTest extends TestCase
     public function testException(): void
     {
         $container = new BasicAutoWiringContainer(new EmptyContainer());
-        $cache = new ApcuCache();
+        $cache = new PhpFilesCache();
 
         $factory = new SchemaFactory($cache, $container);
 
@@ -69,7 +69,7 @@ class SchemaFactoryTest extends TestCase
     public function testException2(): void
     {
         $container = new BasicAutoWiringContainer(new EmptyContainer());
-        $cache = new ApcuCache();
+        $cache = new PhpFilesCache();
 
         $factory = new SchemaFactory($cache, $container);
         $factory->addTypeNamespace('TheCodingMachine\\GraphQL\\Controllers\\Fixtures\\Integration');

--- a/tests/Security/FailAuthenticationServiceTest.php
+++ b/tests/Security/FailAuthenticationServiceTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers\Security;
+
+use PHPUnit\Framework\TestCase;
+
+class FailAuthenticationServiceTest extends TestCase
+{
+
+    public function testIsAllowed()
+    {
+        $service = new FailAuthenticationService();
+        $this->expectException(SecurityNotImplementedException::class);
+        $service->isLogged();
+    }
+}

--- a/tests/Security/FailAuthorizationServiceTest.php
+++ b/tests/Security/FailAuthorizationServiceTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TheCodingMachine\GraphQL\Controllers\Security;
+
+use PHPUnit\Framework\TestCase;
+
+class FailAuthorizationServiceTest extends TestCase
+{
+
+    public function testIsAllowed()
+    {
+        $service = new FailAuthorizationService();
+        $this->expectException(SecurityNotImplementedException::class);
+        $service->isAllowed('foo');
+    }
+}


### PR DESCRIPTION
The SchemaFactory is used to ease the creation of a working setup with the most common defaults.

Also, documentation on how to work with other frameworks has been improved. See #84 